### PR TITLE
Added ability to refresh titles

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -109,6 +109,7 @@ Gui::Gui(void)
 	messageBox->push_message("Hold \uE003 to multiselect all titles.");
 	messageBox->push_message("Press \uE006 to move between titles.");
 	messageBox->push_message("Press \uE004\uE005 to switch page.");
+	messageBox->push_message("Hold \uE001 to refresh titles");
 }
 
 void Gui::createInfo(std::string title, std::string message)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -34,6 +34,7 @@ int main() {
 	servicesInit();
 	
 	int selectionTimer = 0;
+	int refreshTimer = 0;
 	menu = new Gui();
 	
 	createThread((ThreadFunc)threadLoadTitles);
@@ -85,6 +86,21 @@ int main() {
 				addSelectedEntry(i);
 			}
 			selectionTimer = 0;
+		}
+
+		if (hidKeysHeld() & KEY_B)
+		{
+			refreshTimer++;
+		}
+		else
+		{
+			refreshTimer = 0;
+		}
+
+		if (refreshTimer > 90)
+		{
+			createThread((ThreadFunc)threadLoadTitles);
+			refreshTimer = 0;
 		}
 		
 		if (menu->isBackupReleased())

--- a/source/thread.cpp
+++ b/source/thread.cpp
@@ -20,6 +20,8 @@
 
 static std::vector<Thread> threads;
 
+static volatile bool isLoadingTitles = false;
+
 void createThread(ThreadFunc entrypoint)
 {
 	s32 prio = 0;
@@ -39,5 +41,13 @@ void destroyThreads(void)
 
 void threadLoadTitles(void)
 {
+	// don't load titles while they're loading
+	if (isLoadingTitles)
+	{
+		return;
+	}
+
+	isLoadingTitles = true;
 	loadTitles();
+	isLoadingTitles = false;
 }

--- a/source/title.cpp
+++ b/source/title.cpp
@@ -305,6 +305,10 @@ static bool checkHigh(u64 id)
 
 void loadTitles(void)
 {
+	// on refreshing
+	titleSaves.clear();
+	titleExtdatas.clear();
+
 	u32 count = 0;
 	AM_GetTitleCount(MEDIATYPE_SD, &count);
 	titleSaves.reserve(count + 1);


### PR DESCRIPTION
loadTitles clears title[Saves|Extdatas].
threadLoadTitles won't call loadTitles if there is an instance already.

Assigned refreshing titles to holding B down and added instruction to the commands message box.

Addresses issue #5.