### PR TITLE
Add logger class

### DIFF
--- a/switch/include/log.hpp
+++ b/switch/include/log.hpp
@@ -1,0 +1,26 @@
+#ifndef CHECKPOINT_LOG_HPP
+#define CHECKPOINT_LOG_HPP
+
+#include <fstream>
+#include <string>
+
+class Logger {
+private:
+    static Logger *instance;
+    static const std::string filepath;
+
+    // Set this to false if you don't want a log
+    static const bool enabled = true;
+
+    std::fstream out;
+
+    Logger();
+    ~Logger();
+
+public:
+    static Logger *getInstance();
+    void print(std::string s);
+};
+
+
+#endif

--- a/switch/source/log.cpp
+++ b/switch/source/log.cpp
@@ -1,0 +1,28 @@
+//
+// Created by lovingyoung on 18-5-13.
+//
+
+#include <log.hpp>
+
+Logger *Logger::getInstance() {
+    if (instance == 0) {
+        instance = new Logger();
+    }
+
+    return instance;
+}
+
+Logger::Logger() {
+    if(enabled) out.open(filepath, std::ios::app | std::ios::out);
+}
+
+Logger::~Logger() {
+    if(enabled) out.close();
+}
+
+void Logger::print(std::string s) {
+    if(enabled) out << s << std::endl;
+}
+
+const std::string Logger::filepath = "Checkpoint/log.txt";
+Logger* Logger::instance = 0;


### PR DESCRIPTION
Usage:
```
Logger * logger = Logger::getInstance();
logger->print("Log this");
```
Log file is stored in `sdmc:/switch/Checkpoint/log.txt`.

Signed-off-by: Y. Jace Liu <yang.jace.liu@linux.com>