### PR TITLE
Use vasprintf

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -25,6 +25,7 @@
 */
 
 #include "common.hpp"
+#include <stdio.h>
 
 std::string DateTime::timeStr(void)
 {
@@ -80,6 +81,15 @@ std::string StringUtils::removeForbiddenCharacters(std::string src)
 // https://stackoverflow.com/questions/2342162/stdstring-formatting-like-sprintf
 std::string StringUtils::format(const std::string fmt_str, ...)
 {
+#if __GNU_VISIBLE
+    va_list ap;
+    char *fp = NULL;
+    va_start(ap, fmt_str);
+    vasprintf(&fp, fmt_str.c_str(), ap);
+    va_end(ap);
+    std::unique_ptr<char[]> formatted(fp);
+    return std::string(formatted.get());
+#else
     int final_n, n = ((int)fmt_str.size()) * 2; /* Reserve two times as much as the length of the fmt_str */
     std::unique_ptr<char[]> formatted;
     va_list ap;
@@ -96,6 +106,7 @@ std::string StringUtils::format(const std::string fmt_str, ...)
             break;
     }
     return std::string(formatted.get());
+#endif
 }
 
 std::string StringUtils::sizeString(double size)

--- a/switch/Makefile
+++ b/switch/Makefile
@@ -59,7 +59,7 @@ CFLAGS	:=	-g -Wall -O3 -ffunction-sections \
 			-DVERSION_MICRO=${VERSION_MICRO} \
 			`freetype-config --cflags`
 
-CFLAGS	+=	$(INCLUDE) -D__SWITCH__
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -D_GNU_SOURCE=1
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 


### PR DESCRIPTION
This changes StringUtils::format() to use vasprintf() directly, instead of vsnprintf() potentially multiple times. I had to add -D_GNU_SOURCE=1 to the Makefile for this symbol to be visible. Untested, but it does build.