### PR TITLE
Fix bug when refreshing titles and add small check for a better UX

### DIFF
--- a/3ds/source/main.cpp
+++ b/3ds/source/main.cpp
@@ -104,7 +104,7 @@ int main() {
             selectionTimer = 0;
         }
 
-        if (kHeld & KEY_B)
+        if (kHeld & KEY_B && !Gui::bottomScroll())
         {
             refreshTimer++;
         }

--- a/3ds/source/main.cpp
+++ b/3ds/source/main.cpp
@@ -116,7 +116,6 @@ int main() {
         if (refreshTimer > 90)
         {
             Gui::resetIndex();
-            Archive::mode(Archive::mode() == MODE_SAVE ? MODE_EXTDATA : MODE_SAVE);
             Gui::clearSelectedEntries();
             Gui::resetScrollableIndex();            
             Threads::create((ThreadFunc)Threads::titles);


### PR DESCRIPTION
Commit [6a5c1aa](https://github.com/BernardoGiordano/Checkpoint/commit/6a5c1aa04ccceb5d6f0f75d2d9f4a3bf08cd988f):
This fixes a bug where holding B would not only refresh the user's titles, but also switch modes too from saves mode -> extdata mode and vice versa, depending on what mode it's in before holding B.
This commit fixes what appears to be a copy&paste issue.

Commit [be1ae42](https://github.com/BernardoGiordano/Checkpoint/commit/be1ae4297cbd00c21a087528788f87fe266a2b47):
This commit just makes it so that titles can't be refreshed while using the bottom screen UI. It's purely just for user experience. 
Although holding B will also exit the bottom screen UI due to the `kDown`, the user can still press A to re-enter the bottom screen UI, meaning it'll be active during and after the title refresh. As stated already, this change is just for user experience and doesn't actually change much in regard to functionality.