### PR TITLE
Add an include to fix a 3ds build failure on Windows.

### DIFF
--- a/3ds/source/spi.cpp
+++ b/3ds/source/spi.cpp
@@ -43,6 +43,7 @@
  */
 
 #include "spi.hpp"
+#include <vector>
 
 static std::vector<u32> knownJEDECs = {0x204012, 0x621600, 0x204013, 0x621100, 0x204014, 0x202017, 0x204017, 0x208013};
 


### PR DESCRIPTION
Let me know if there's some more appropriate fix. But this seems to have resolved the 3ds build for me.

```
M:/GitHub/Checkpoint/3ds/source/spi.cpp:47:13: error: 'vector' in namespace 'std' does not name a template type
   47 | static std::vector<u32> knownJEDECs = {0x204012, 0x621600, 0x204013, 0x621100, 0x204014, 0x202017, 0x204017, 0x208013};
      |             ^~~~~~
M:/GitHub/Checkpoint/3ds/source/spi.cpp:46:1: note: 'std::vector' is defined in header '<vector>'; did you forget to '#include <vector>'?
   45 | #include "spi.hpp"
  +++ |+#include <vector>
   46 |
```