### PR TITLE
Fixed L/R double binding

### DIFF
--- a/common/ihid.tcc
+++ b/common/ihid.tcc
@@ -35,13 +35,7 @@ void IHid<ListDirection, PageDirection, Delay>::update(size_t count)
 
     mMaxPages = (count % mMaxVisibleEntries == 0) ? count / mMaxVisibleEntries : count / mMaxVisibleEntries + 1;
 
-    if (leftTriggerDown()) {
-        pageBack();
-    }
-    else if (rightTriggerDown()) {
-        pageForward();
-    }
-    else if (leftTriggerHeld()) {
+    if (leftTriggerHeld()) {
         if (currentTime <= mLastTime + Delay) {
             return;
         }


### PR DESCRIPTION
Fixes issue #455, which could cause users to accidentally override their saves or restoring the wrong one. 