### PR TITLE
This PR adds local Wi‑Fi backup transfer between 3DS consoles.

### DIFF
--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -86,7 +86,7 @@ CFLAGS	:=	-g -gdwarf-4 -Wall -Wextra -Wno-psabi -O3 -mword-relocations -flto=aut
 
 CFLAGS	+=	$(INCLUDE) -DARM11 -D__3DS__ -D_GNU_SOURCE=1
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -std=gnu++23
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -std=gnu++23 -fpermissive
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -86,15 +86,18 @@ CFLAGS	:=	-g -gdwarf-4 -Wall -Wextra -Wno-psabi -O3 -mword-relocations -flto=aut
 
 CFLAGS	+=	$(INCLUDE) -DARM11 -D__3DS__ -D_GNU_SOURCE=1
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -std=gnu++23 -fpermissive
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -std=gnu++23 
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lbz2 -lcitro2d -lcitro3d -lctru -lm
 
-CXX		:= `which ccache` $(CXX)
-CC		:= `which ccache` $(CC)
+CCACHE	:=	$(shell command -v ccache 2>/dev/null)
+ifneq ($(strip $(CCACHE)),)
+CXX		:=	$(CCACHE) $(CXX)
+CC		:=	$(CCACHE) $(CC)
+endif
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -86,7 +86,7 @@ CFLAGS	:=	-g -gdwarf-4 -Wall -Wextra -Wno-psabi -O3 -mword-relocations -flto=aut
 
 CFLAGS	+=	$(INCLUDE) -DARM11 -D__3DS__ -D_GNU_SOURCE=1
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -std=gnu++23 
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -std=gnu++23
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/3ds/include/MainScreen.hpp
+++ b/3ds/include/MainScreen.hpp
@@ -57,6 +57,7 @@ protected:
     void handleEvents(const InputState& input);
     void updateSelector(void);
     void updateButtons(void);
+    void refreshTitlesFull(void);
     std::string nameFromCell(size_t index) const;
     void startTransferSend(void);
 

--- a/3ds/include/MainScreen.hpp
+++ b/3ds/include/MainScreen.hpp
@@ -31,6 +31,7 @@
 #include "ErrorOverlay.hpp"
 #include "InfoOverlay.hpp"
 #include "Screen.hpp"
+#include "TransferOverlay.hpp"
 #include "YesNoOverlay.hpp"
 #include "clickable.hpp"
 #include "gui.hpp"
@@ -57,10 +58,11 @@ protected:
     void updateSelector(void);
     void updateButtons(void);
     std::string nameFromCell(size_t index) const;
+    void startTransferSend(void);
 
 private:
     Hid<HidDirection::HORIZONTAL, HidDirection::VERTICAL> hid;
-    std::unique_ptr<Clickable> buttonBackup, buttonRestore, buttonCheats, buttonPlayCoins;
+    std::unique_ptr<Clickable> buttonBackup, buttonRestore, buttonCheats, buttonPlayCoins, buttonTransfer;
     std::unique_ptr<Scrollable> directoryList;
     char ver[10];
 

--- a/3ds/include/TransferOverlay.hpp
+++ b/3ds/include/TransferOverlay.hpp
@@ -24,34 +24,45 @@
  *         reasonable ways as different from the original version.
  */
 
-#ifndef MAIN_HPP
-#define MAIN_HPP
+#ifndef TRANSFEROVERLAY_HPP
+#define TRANSFEROVERLAY_HPP
 
-#include "Screen.hpp"
-#include "logging.hpp"
-#include <atomic>
-#include <citro2d.h>
+#include "Overlay.hpp"
+#include "clickable.hpp"
+#include "colors.hpp"
+#include "gui.hpp"
+#include "hid.hpp"
+#include <functional>
 #include <memory>
-#include <vector>
+#include <string>
 
-inline std::shared_ptr<Screen> g_screen = nullptr;
-inline bool g_bottomScrollEnabled       = false;
-inline float g_timer                    = 0;
-inline std::string g_selectedCheatKey;
-inline std::vector<std::string> g_selectedCheatCodes;
-inline std::atomic<bool> g_isLoadingTitles = false;
-inline int g_loadingTitlesCounter          = 0;
-inline int g_loadingTitlesLimit            = 0;
+class TransferMenuOverlay : public Overlay {
+public:
+    TransferMenuOverlay(Screen& screen, const std::function<void()>& callbackSend, const std::function<void()>& callbackReceive);
+    ~TransferMenuOverlay(void);
+    void drawTop(void) const override;
+    void drawBottom(void) const override;
+    void update(const InputState& input) override;
 
-inline std::u16string g_currentFile;
-inline bool g_isTransferringFile = false;
-inline size_t g_copyCount        = 0;
-inline size_t g_copyTotal        = 0;
-inline std::string g_transferMode;
-inline u32 g_currentFileOffset = 0;
-inline u32 g_currentFileSize   = 0;
-inline bool g_transferIsNetwork = false;
-inline u64 g_transferBytesDone  = 0;
-inline u64 g_transferBytesTotal = 0;
+private:
+    u32 posx, posy;
+    C2D_TextBuf textBuf;
+    C2D_Text text;
+    std::unique_ptr<Clickable> buttonSend, buttonReceive;
+    Hid<HidDirection::HORIZONTAL, HidDirection::HORIZONTAL> hid;
+    std::function<void()> sendFunc, receiveFunc;
+};
+
+class ReceiveOverlay : public Overlay {
+public:
+    ReceiveOverlay(Screen& screen);
+    ~ReceiveOverlay(void);
+    void drawTop(void) const override;
+    void drawBottom(void) const override;
+    void update(const InputState& input) override;
+
+private:
+    C2D_TextBuf textBuf;
+};
 
 #endif

--- a/3ds/include/loader.hpp
+++ b/3ds/include/loader.hpp
@@ -34,6 +34,8 @@
 namespace TitleLoader {
     void getTitle(Title& dst, int i);
     bool getTitleById(Title& dst, u64 id);
+    bool getTitleByName(Title& dst, const std::string& name);
+    void refreshAllDirectories(void);
     int getTitleCount(void);
     C2D_Image icon(int i);
     bool favorite(int i);

--- a/3ds/include/loader.hpp
+++ b/3ds/include/loader.hpp
@@ -33,6 +33,7 @@
 
 namespace TitleLoader {
     void getTitle(Title& dst, int i);
+    bool getTitleById(Title& dst, u64 id);
     int getTitleCount(void);
     C2D_Image icon(int i);
     bool favorite(int i);

--- a/3ds/include/main.hpp
+++ b/3ds/include/main.hpp
@@ -32,6 +32,8 @@
 #include <atomic>
 #include <citro2d.h>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <vector>
 
 inline std::shared_ptr<Screen> g_screen = nullptr;
@@ -53,5 +55,49 @@ inline u32 g_currentFileSize   = 0;
 inline bool g_transferIsNetwork = false;
 inline u64 g_transferBytesDone  = 0;
 inline u64 g_transferBytesTotal = 0;
+
+// g_transferMode and the byte counters are written by the HTTP server thread
+// (while receiving) and read by the UI thread, so all access must go through
+// these helpers. Concurrent access to the std::string is otherwise undefined
+// behavior, and 64-bit reads tear on the 3DS's 32-bit core.
+inline std::mutex g_transferStatusMutex;
+
+inline void transferSetMode(const std::string& mode)
+{
+    std::lock_guard<std::mutex> lock(g_transferStatusMutex);
+    g_transferMode = mode;
+}
+
+inline std::string transferGetMode(void)
+{
+    std::lock_guard<std::mutex> lock(g_transferStatusMutex);
+    return g_transferMode;
+}
+
+inline void transferSetProgress(u64 done, u64 total)
+{
+    std::lock_guard<std::mutex> lock(g_transferStatusMutex);
+    g_transferBytesDone  = done;
+    g_transferBytesTotal = total;
+}
+
+inline void transferSetDone(u64 done)
+{
+    std::lock_guard<std::mutex> lock(g_transferStatusMutex);
+    g_transferBytesDone = done;
+}
+
+inline void transferAddDone(u64 delta)
+{
+    std::lock_guard<std::mutex> lock(g_transferStatusMutex);
+    g_transferBytesDone += delta;
+}
+
+inline void transferGetProgress(u64& done, u64& total)
+{
+    std::lock_guard<std::mutex> lock(g_transferStatusMutex);
+    done  = g_transferBytesDone;
+    total = g_transferBytesTotal;
+}
 
 #endif

--- a/3ds/include/main.hpp
+++ b/3ds/include/main.hpp
@@ -31,6 +31,7 @@
 #include "logging.hpp"
 #include <atomic>
 #include <citro2d.h>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -98,6 +99,14 @@ inline void transferGetProgress(u64& done, u64& total)
     std::lock_guard<std::mutex> lock(g_transferStatusMutex);
     done  = g_transferBytesDone;
     total = g_transferBytesTotal;
+}
+
+// Formats a "done / total" byte pair in MB for the transfer progress UI.
+inline std::string transferBytesToMB(u64 done, u64 total)
+{
+    char buf[48];
+    snprintf(buf, sizeof(buf), "%.1f / %.1f MB", (double)done / (1024.0 * 1024.0), (double)total / (1024.0 * 1024.0));
+    return std::string(buf);
 }
 
 #endif

--- a/3ds/include/title.hpp
+++ b/3ds/include/title.hpp
@@ -60,7 +60,7 @@ public:
     std::u16string fullExtdataPath(size_t index);
     u32 highId(void);
     C2D_Image icon(void);
-    u64 id(void);
+    u64 id(void) const;
     bool isActivityLog(void);
     void load(void);
     bool load(u64 id, FS_MediaType mediaType, FS_CardType cardType);
@@ -76,7 +76,7 @@ public:
     std::u16string fullSavePath(size_t index);
     std::vector<std::u16string> saves(void);
     void setIcon(C2D_Image icon);
-    std::string shortDescription(void);
+    std::string shortDescription(void) const;
     std::u16string getShortDescription(void);
     CardType SPICardType(void);
     u32 uniqueId(void);

--- a/3ds/include/transfer.hpp
+++ b/3ds/include/transfer.hpp
@@ -24,34 +24,24 @@
  *         reasonable ways as different from the original version.
  */
 
-#ifndef MAIN_HPP
-#define MAIN_HPP
+#ifndef TRANSFER_HPP
+#define TRANSFER_HPP
 
-#include "Screen.hpp"
-#include "logging.hpp"
-#include <atomic>
-#include <citro2d.h>
-#include <memory>
-#include <vector>
+#include "title.hpp"
+#include <string>
 
-inline std::shared_ptr<Screen> g_screen = nullptr;
-inline bool g_bottomScrollEnabled       = false;
-inline float g_timer                    = 0;
-inline std::string g_selectedCheatKey;
-inline std::vector<std::string> g_selectedCheatCodes;
-inline std::atomic<bool> g_isLoadingTitles = false;
-inline int g_loadingTitlesCounter          = 0;
-inline int g_loadingTitlesLimit            = 0;
+namespace Transfer {
+    bool startReceiver(std::string& outError);
+    void stopReceiver(void);
+    bool receiverRunning(void);
+    std::string receiverToken(void);
+    std::string receiverIp(void);
+    int receiverPort(void);
+    std::string receiverNotice(void);
+    void clearReceiverNotice(void);
 
-inline std::u16string g_currentFile;
-inline bool g_isTransferringFile = false;
-inline size_t g_copyCount        = 0;
-inline size_t g_copyTotal        = 0;
-inline std::string g_transferMode;
-inline u32 g_currentFileOffset = 0;
-inline u32 g_currentFileSize   = 0;
-inline bool g_transferIsNetwork = false;
-inline u64 g_transferBytesDone  = 0;
-inline u64 g_transferBytesTotal = 0;
+    bool sendBackup(const Title& title, const std::u16string& backupPath, const std::string& backupName, const std::string& dataType,
+        const std::string& ip, u16 port, const std::string& token, std::string& outError);
+}
 
 #endif

--- a/3ds/include/transfer.hpp
+++ b/3ds/include/transfer.hpp
@@ -34,11 +34,15 @@ namespace Transfer {
     bool startReceiver(std::string& outError);
     void stopReceiver(void);
     bool receiverRunning(void);
+    bool consumePendingRefresh(void);
     std::string receiverToken(void);
     std::string receiverIp(void);
     int receiverPort(void);
     std::string receiverNotice(void);
+    bool receiverHasCompleted(void);
+    std::string receiverCompletedName(void);
     void clearReceiverNotice(void);
+    void clearReceiverCompletion(void);
 
     bool sendBackup(const Title& title, const std::u16string& backupPath, const std::string& backupName, const std::string& dataType,
         const std::string& ip, u16 port, const std::string& token, std::string& outError);

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -65,7 +65,7 @@ MainScreen::MainScreen(void) : hid(rowlen * collen, collen)
     buttonRestore   = std::make_unique<Clickable>(204, 139, 110, 35, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Restore \uE005", true);
     buttonCheats    = std::make_unique<Clickable>(204, 176, 110, 36, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Cheats", true);
     buttonPlayCoins = std::make_unique<Clickable>(204, 176, 110, 36, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "\uE075 Coins", true);
-    buttonTransfer  = std::make_unique<Clickable>(4, 223, 110, 16, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Transferir", true);
+    buttonTransfer  = std::make_unique<Clickable>(4, 223, 110, 16, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Transfer", true);
     directoryList   = std::make_unique<Scrollable>(6, 102, 196, 110, 5);
     buttonBackup->canChangeColorWhenSelected(true);
     buttonRestore->canChangeColorWhenSelected(true);
@@ -446,8 +446,20 @@ void MainScreen::drawBottom(void) const
 
 void MainScreen::update(const InputState& input)
 {
+    if (Transfer::consumePendingRefresh()) {
+        refreshTitlesFull();
+    }
     updateSelector();
     handleEvents(input);
+}
+
+void MainScreen::refreshTitlesFull(void)
+{
+    hid.reset();
+    MS::clearSelectedEntries();
+    directoryList->resetIndex();
+    Threads::executeTask(TitleLoader::loadTitlesThread);
+    refreshTimer = 0;
 }
 
 void MainScreen::updateSelector(void)
@@ -590,11 +602,7 @@ void MainScreen::handleEvents(const InputState& input)
     }
 
     if (refreshTimer > 90) {
-        hid.reset();
-        MS::clearSelectedEntries();
-        directoryList->resetIndex();
-        Threads::executeTask(TitleLoader::loadTitlesThread);
-        refreshTimer = 0;
+        refreshTitlesFull();
     }
 
     if (buttonTransfer->released()) {
@@ -816,6 +824,11 @@ void MainScreen::startTransferSend(void)
         currentOverlay = std::make_shared<InfoOverlay>(*this, "Transfer completed.");
     }
     else {
-        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, error.empty() ? "Transfer failed." : error);
+        if (error == "Selected backup is empty.") {
+            currentOverlay = std::make_shared<InfoOverlay>(*this, error);
+        }
+        else {
+            currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, error.empty() ? "Transfer failed." : error);
+        }
     }
 }

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -233,7 +233,7 @@ void MainScreen::drawTop(void) const
                 u64 total = g_transferBytesTotal;
                 u64 done  = g_transferBytesDone;
                 int pct   = total > 0 ? (int)((done * 100) / total) : 0;
-                std::string prefix = g_transferMode.empty() ? "Transferencia" : g_transferMode;
+                std::string prefix = g_transferMode.empty() ? "Transferring backup" : g_transferMode;
                 modeStr = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
             }
             else {
@@ -330,7 +330,7 @@ void MainScreen::drawBottom(void) const
             u64 total = g_transferBytesTotal;
             u64 done  = g_transferBytesDone;
             int pct   = total > 0 ? (int)((done * 100) / total) : 0;
-            std::string prefix = g_transferMode.empty() ? "Transferencia" : g_transferMode;
+            std::string prefix = g_transferMode.empty() ? "Transferring backup" : g_transferMode;
             std::string titleStr = StringUtils::format("%s... %d%%", prefix.c_str(), pct);
 
             C2D_Text titleText;

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -265,10 +265,9 @@ void MainScreen::drawBottom(void) const
 
         directoryList->flush();
         std::vector<std::u16string> dirs = mode == MODE_SAVE ? title.saves() : title.extdata();
-        static std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
 
         for (size_t i = 0; i < dirs.size(); i++) {
-            directoryList->push_back(COLOR_BLACK_DARKERR, COLOR_WHITE, convert.to_bytes(dirs.at(i)), i == directoryList->index());
+            directoryList->push_back(COLOR_BLACK_DARKERR, COLOR_WHITE, StringUtils::UTF16toUTF8(dirs.at(i)), i == directoryList->index());
         }
 
         C2D_Text longDesc, c2dTitleInfo;

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -27,8 +27,31 @@
 #include "MainScreen.hpp"
 #include "loader.hpp"
 #include "server.hpp"
+#include "transfer.hpp"
+#include <3ds.h>
+#include <cctype>
 
 static constexpr size_t rowlen = 4, collen = 8;
+
+namespace {
+    std::string rawKeyboard(const std::string& suggestion, const std::string& hint, size_t maxLen)
+    {
+        SwkbdState swkbd;
+        const size_t kBufSize = 64;
+        size_t limit = std::min(maxLen, kBufSize);
+        if (limit < 2) {
+            limit = 2;
+        }
+        swkbdInit(&swkbd, SWKBD_TYPE_NORMAL, 2, limit - 1);
+        swkbdSetValidation(&swkbd, SWKBD_NOTBLANK_NOTEMPTY, 0, 0);
+        swkbdSetInitialText(&swkbd, suggestion.c_str());
+        swkbdSetHintText(&swkbd, hint.c_str());
+        char buf[kBufSize] = {0};
+        SwkbdButton button = swkbdInputText(&swkbd, buf, sizeof(buf));
+        buf[sizeof(buf) - 1] = '\0';
+        return button == SWKBD_BUTTON_CONFIRM ? std::string(buf) : std::string();
+    }
+}
 
 MainScreen::MainScreen(void) : hid(rowlen * collen, collen)
 {
@@ -42,11 +65,13 @@ MainScreen::MainScreen(void) : hid(rowlen * collen, collen)
     buttonRestore   = std::make_unique<Clickable>(204, 139, 110, 35, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Restore \uE005", true);
     buttonCheats    = std::make_unique<Clickable>(204, 176, 110, 36, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Cheats", true);
     buttonPlayCoins = std::make_unique<Clickable>(204, 176, 110, 36, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "\uE075 Coins", true);
+    buttonTransfer  = std::make_unique<Clickable>(4, 223, 110, 16, COLOR_BLACK_DARKERR, COLOR_GREY_LIGHT, "Transferir", true);
     directoryList   = std::make_unique<Scrollable>(6, 102, 196, 110, 5);
     buttonBackup->canChangeColorWhenSelected(true);
     buttonRestore->canChangeColorWhenSelected(true);
     buttonCheats->canChangeColorWhenSelected(true);
     buttonPlayCoins->canChangeColorWhenSelected(true);
+    buttonTransfer->canChangeColorWhenSelected(true);
 
     sprintf(ver, "v%d.%d.%d", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
 
@@ -202,8 +227,18 @@ void MainScreen::drawTop(void) const
         if (g_isTransferringFile) {
             C2D_DrawRectSolid(0, 0, 0.5f, 400, 240, COLOR_OVERLAY);
 
-            const float size    = 0.7f;
-            std::string modeStr = (g_transferMode.empty() ? "Copying files" : g_transferMode) + " in progress...";
+            const float size = 0.7f;
+            std::string modeStr;
+            if (g_transferIsNetwork) {
+                u64 total = g_transferBytesTotal;
+                u64 done  = g_transferBytesDone;
+                int pct   = total > 0 ? (int)((done * 100) / total) : 0;
+                std::string prefix = g_transferMode.empty() ? "Transferencia" : g_transferMode;
+                modeStr = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
+            }
+            else {
+                modeStr = (g_transferMode.empty() ? "Copying files" : g_transferMode) + " in progress...";
+            }
             C2D_Text modeText;
             C2D_TextParse(&modeText, dynamicBuf, modeStr.c_str());
             C2D_TextOptimize(&modeText);
@@ -273,7 +308,9 @@ void MainScreen::drawBottom(void) const
         }
     }
 
-    C2D_DrawText(&ins4, C2D_WithColor, ceilf((320 - ins4.width * 0.47f) / 2), 223, 0.5f, 0.47f, 0.47f, COLOR_GREY_LIGHT);
+    buttonTransfer->draw(0.55f, COLOR_PURPLE_LIGHT);
+    C2D_DrawText(
+        &ins4, C2D_WithColor, ceilf(320 - StringUtils::textWidth(ins4, 0.47f) - 4), 223, 0.5f, 0.47f, 0.47f, COLOR_GREY_LIGHT);
 
     if (hidKeysHeld() & KEY_SELECT) {
         C2D_DrawRectSolid(0, 0, 0.5f, 320, 240, COLOR_OVERLAY);
@@ -286,86 +323,125 @@ void MainScreen::drawBottom(void) const
     if (g_isTransferringFile) {
         C2D_DrawRectSolid(0, 0, 0.5f, 320, 240, COLOR_OVERLAY);
 
-        // Modal box
-        const int mx = 30, my = 65, mw = 260, mh = 130;
-        C2D_DrawRectSolid(mx, my, 0.5f, mw, mh, COLOR_BLACK_DARKERR);
-        Gui::drawOutline(mx, my, mw, mh, 2, COLOR_PURPLE_LIGHT);
+        if (g_transferIsNetwork) {
+            const int mx = 30, my = 65, mw = 260, mh = 110;
+            C2D_DrawRectSolid(mx, my, 0.5f, mw, mh, COLOR_BLACK_DARKERR);
+            Gui::drawOutline(mx, my, mw, mh, 2, COLOR_PURPLE_LIGHT);
 
-        // Title
-        std::string titleStr = (g_transferMode.empty() ? "Copying files" : g_transferMode) + " in progress...";
-        C2D_Text titleText;
-        C2D_TextParse(&titleText, dynamicBuf, titleStr.c_str());
-        C2D_TextOptimize(&titleText);
-        C2D_DrawText(
-            &titleText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(titleText, 0.55f)) / 2), my + 10, 0.5f, 0.55f, 0.55f, COLOR_WHITE);
+            u64 total = g_transferBytesTotal;
+            u64 done  = g_transferBytesDone;
+            int pct   = total > 0 ? (int)((done * 100) / total) : 0;
+            std::string prefix = g_transferMode.empty() ? "Transferencia" : g_transferMode;
+            std::string titleStr = StringUtils::format("%s... %d%%", prefix.c_str(), pct);
 
-        // Current filename
-        std::string fname = StringUtils::UTF16toUTF8(g_currentFile);
-        C2D_Text fileText;
-        C2D_TextParse(&fileText, dynamicBuf, fname.c_str());
-        C2D_TextOptimize(&fileText);
-        C2D_DrawText(
-            &fileText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(fileText, 0.5f)) / 2), my + 30, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
+            C2D_Text titleText;
+            C2D_TextParse(&titleText, dynamicBuf, titleStr.c_str());
+            C2D_TextOptimize(&titleText);
+            C2D_DrawText(
+                &titleText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(titleText, 0.55f)) / 2), my + 10, 0.5f, 0.55f, 0.55f, COLOR_WHITE);
 
-        const int barX = mx + 12, barW = mw - 24, barH = 10;
+            std::string bytesStr = StringUtils::format("%llu / %llu", (unsigned long long)done, (unsigned long long)total);
+            C2D_Text bytesText;
+            C2D_TextParse(&bytesText, dynamicBuf, bytesStr.c_str());
+            C2D_TextOptimize(&bytesText);
+            C2D_DrawText(
+                &bytesText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(bytesText, 0.5f)) / 2), my + 38, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
 
-        // Per-save progress bar
-        const int saveBarY = my + 52;
-        C2D_DrawRectSolid(barX, saveBarY, 0.5f, barW, barH, COLOR_BLACK_MEDIUM);
-
-        float progress = (g_copyTotal > 0) ? (float)g_copyCount / (float)g_copyTotal : 0.0f;
-        if (progress > 1.0f)
-            progress = 1.0f;
-        int saveFillW = (int)(barW * progress);
-        if (saveFillW > 0) {
-            C2D_DrawRectSolid(barX, saveBarY, 0.5f, saveFillW, barH, COLOR_PURPLE_LIGHT);
+            const int barX = mx + 12, barW = mw - 24, barH = 10;
+            const int barY = my + 65;
+            C2D_DrawRectSolid(barX, barY, 0.5f, barW, barH, COLOR_BLACK_MEDIUM);
+            float progress = (total > 0) ? (float)done / (float)total : 0.0f;
+            if (progress > 1.0f) {
+                progress = 1.0f;
+            }
+            int fillW = (int)(barW * progress);
+            if (fillW > 0) {
+                C2D_DrawRectSolid(barX, barY, 0.5f, fillW, barH, COLOR_PURPLE_LIGHT);
+            }
+            Gui::drawOutline(barX, barY, barW, barH, 1, COLOR_GREY_LIGHT);
         }
-        Gui::drawOutline(barX, saveBarY, barW, barH, 1, COLOR_GREY_LIGHT);
+        else {
+            // Modal box
+            const int mx = 30, my = 65, mw = 260, mh = 130;
+            C2D_DrawRectSolid(mx, my, 0.5f, mw, mh, COLOR_BLACK_DARKERR);
+            Gui::drawOutline(mx, my, mw, mh, 2, COLOR_PURPLE_LIGHT);
 
-        // Count (left) and percentage (right) below per-save bar
-        char countStr[24];
-        snprintf(countStr, sizeof(countStr), "%zu / %zu", g_copyCount, g_copyTotal);
-        C2D_Text countText;
-        C2D_TextParse(&countText, dynamicBuf, countStr);
-        C2D_TextOptimize(&countText);
-        C2D_DrawText(&countText, C2D_WithColor, barX, saveBarY + barH + 3, 0.5f, 0.45f, 0.45f, COLOR_GREY_LIGHT);
+            // Title
+            std::string titleStr = (g_transferMode.empty() ? "Copying files" : g_transferMode) + " in progress...";
+            C2D_Text titleText;
+            C2D_TextParse(&titleText, dynamicBuf, titleStr.c_str());
+            C2D_TextOptimize(&titleText);
+            C2D_DrawText(
+                &titleText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(titleText, 0.55f)) / 2), my + 10, 0.5f, 0.55f, 0.55f, COLOR_WHITE);
 
-        char pctStr[8];
-        snprintf(pctStr, sizeof(pctStr), "%d%%", (int)(progress * 100));
-        C2D_Text pctText;
-        C2D_TextParse(&pctText, dynamicBuf, pctStr);
-        C2D_TextOptimize(&pctText);
-        C2D_DrawText(&pctText, C2D_WithColor, barX + barW - ceilf(StringUtils::textWidth(pctText, 0.45f)), saveBarY + barH + 3, 0.5f, 0.45f, 0.45f,
-            COLOR_WHITE);
+            // Current filename
+            std::string fname = StringUtils::UTF16toUTF8(g_currentFile);
+            C2D_Text fileText;
+            C2D_TextParse(&fileText, dynamicBuf, fname.c_str());
+            C2D_TextOptimize(&fileText);
+            C2D_DrawText(
+                &fileText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(fileText, 0.5f)) / 2), my + 30, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
 
-        // Per-file progress bar
-        const int fileBarY = my + 82;
-        C2D_DrawRectSolid(barX, fileBarY, 0.5f, barW, barH, COLOR_BLACK_MEDIUM);
+            const int barX = mx + 12, barW = mw - 24, barH = 10;
 
-        float fileProgress = (g_currentFileSize > 0) ? (float)g_currentFileOffset / (float)g_currentFileSize : 0.0f;
-        if (fileProgress > 1.0f)
-            fileProgress = 1.0f;
-        int fileFillW = (int)(barW * fileProgress);
-        if (fileFillW > 0) {
-            C2D_DrawRectSolid(barX, fileBarY, 0.5f, fileFillW, barH, COLOR_PURPLE_LIGHT);
+            // Per-save progress bar
+            const int saveBarY = my + 52;
+            C2D_DrawRectSolid(barX, saveBarY, 0.5f, barW, barH, COLOR_BLACK_MEDIUM);
+
+            float progress = (g_copyTotal > 0) ? (float)g_copyCount / (float)g_copyTotal : 0.0f;
+            if (progress > 1.0f)
+                progress = 1.0f;
+            int saveFillW = (int)(barW * progress);
+            if (saveFillW > 0) {
+                C2D_DrawRectSolid(barX, saveBarY, 0.5f, saveFillW, barH, COLOR_PURPLE_LIGHT);
+            }
+            Gui::drawOutline(barX, saveBarY, barW, barH, 1, COLOR_GREY_LIGHT);
+
+            // Count (left) and percentage (right) below per-save bar
+            char countStr[24];
+            snprintf(countStr, sizeof(countStr), "%zu / %zu", g_copyCount, g_copyTotal);
+            C2D_Text countText;
+            C2D_TextParse(&countText, dynamicBuf, countStr);
+            C2D_TextOptimize(&countText);
+            C2D_DrawText(&countText, C2D_WithColor, barX, saveBarY + barH + 3, 0.5f, 0.45f, 0.45f, COLOR_GREY_LIGHT);
+
+            char pctStr[8];
+            snprintf(pctStr, sizeof(pctStr), "%d%%", (int)(progress * 100));
+            C2D_Text pctText;
+            C2D_TextParse(&pctText, dynamicBuf, pctStr);
+            C2D_TextOptimize(&pctText);
+            C2D_DrawText(&pctText, C2D_WithColor, barX + barW - ceilf(StringUtils::textWidth(pctText, 0.45f)), saveBarY + barH + 3, 0.5f, 0.45f,
+                0.45f, COLOR_WHITE);
+
+            // Per-file progress bar
+            const int fileBarY = my + 82;
+            C2D_DrawRectSolid(barX, fileBarY, 0.5f, barW, barH, COLOR_BLACK_MEDIUM);
+
+            float fileProgress = (g_currentFileSize > 0) ? (float)g_currentFileOffset / (float)g_currentFileSize : 0.0f;
+            if (fileProgress > 1.0f)
+                fileProgress = 1.0f;
+            int fileFillW = (int)(barW * fileProgress);
+            if (fileFillW > 0) {
+                C2D_DrawRectSolid(barX, fileBarY, 0.5f, fileFillW, barH, COLOR_PURPLE_LIGHT);
+            }
+            Gui::drawOutline(barX, fileBarY, barW, barH, 1, COLOR_GREY_LIGHT);
+
+            // KB transferred (left) and percentage (right) below per-file bar
+            char kbStr[32];
+            snprintf(kbStr, sizeof(kbStr), "%.1f / %.1f KB", g_currentFileOffset / 1024.0f, g_currentFileSize / 1024.0f);
+            C2D_Text kbText;
+            C2D_TextParse(&kbText, dynamicBuf, kbStr);
+            C2D_TextOptimize(&kbText);
+            C2D_DrawText(&kbText, C2D_WithColor, barX, fileBarY + barH + 3, 0.5f, 0.45f, 0.45f, COLOR_GREY_LIGHT);
+
+            char filePctStr[8];
+            snprintf(filePctStr, sizeof(filePctStr), "%d%%", (int)(fileProgress * 100));
+            C2D_Text filePctText;
+            C2D_TextParse(&filePctText, dynamicBuf, filePctStr);
+            C2D_TextOptimize(&filePctText);
+            C2D_DrawText(&filePctText, C2D_WithColor, barX + barW - ceilf(StringUtils::textWidth(filePctText, 0.45f)), fileBarY + barH + 3, 0.5f,
+                0.45f, 0.45f, COLOR_WHITE);
         }
-        Gui::drawOutline(barX, fileBarY, barW, barH, 1, COLOR_GREY_LIGHT);
-
-        // KB transferred (left) and percentage (right) below per-file bar
-        char kbStr[32];
-        snprintf(kbStr, sizeof(kbStr), "%.1f / %.1f KB", g_currentFileOffset / 1024.0f, g_currentFileSize / 1024.0f);
-        C2D_Text kbText;
-        C2D_TextParse(&kbText, dynamicBuf, kbStr);
-        C2D_TextOptimize(&kbText);
-        C2D_DrawText(&kbText, C2D_WithColor, barX, fileBarY + barH + 3, 0.5f, 0.45f, 0.45f, COLOR_GREY_LIGHT);
-
-        char filePctStr[8];
-        snprintf(filePctStr, sizeof(filePctStr), "%d%%", (int)(fileProgress * 100));
-        C2D_Text filePctText;
-        C2D_TextParse(&filePctText, dynamicBuf, filePctStr);
-        C2D_TextOptimize(&filePctText);
-        C2D_DrawText(&filePctText, C2D_WithColor, barX + barW - ceilf(StringUtils::textWidth(filePctText, 0.45f)), fileBarY + barH + 3, 0.5f, 0.45f,
-            0.45f, COLOR_WHITE);
     }
 }
 
@@ -522,6 +598,23 @@ void MainScreen::handleEvents(const InputState& input)
         refreshTimer = 0;
     }
 
+    if (buttonTransfer->released()) {
+        currentOverlay = std::make_shared<TransferMenuOverlay>(
+            *this,
+            [this]() {
+                this->removeOverlay();
+                this->startTransferSend();
+            },
+            [this]() {
+                std::string error;
+                if (!Transfer::startReceiver(error)) {
+                    this->currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, error.empty() ? "Failed to start receiver." : error);
+                    return;
+                }
+                this->currentOverlay = std::make_shared<ReceiveOverlay>(*this);
+            });
+    }
+
     if (buttonBackup->released() || (kDown & KEY_L)) {
         if (MS::multipleSelectionEnabled()) {
             directoryList->resetIndex();
@@ -668,4 +761,62 @@ void MainScreen::updateButtons(void)
 std::string MainScreen::nameFromCell(size_t index) const
 {
     return directoryList->cellName(index);
+}
+
+void MainScreen::startTransferSend(void)
+{
+    if (TitleLoader::getTitleCount() <= 0) {
+        currentOverlay = std::make_shared<InfoOverlay>(*this, "No titles available.");
+        return;
+    }
+
+    size_t cellIndex = directoryList->index();
+    if (!g_bottomScrollEnabled || cellIndex == 0) {
+        currentOverlay = std::make_shared<InfoOverlay>(*this, "Select a backup to send.");
+        return;
+    }
+
+    Title title;
+    TitleLoader::getTitle(title, hid.fullIndex());
+
+    std::string backupName = nameFromCell(cellIndex);
+    std::u16string backupPath = Archive::mode() == MODE_SAVE ? title.fullSavePath(cellIndex) : title.fullExtdataPath(cellIndex);
+
+    std::string ipPort = rawKeyboard("192.168.1.10:8000", "IP:PUERTO del receptor", 32);
+    if (ipPort.empty()) {
+        return;
+    }
+
+    size_t colon = ipPort.find(':');
+    if (colon == std::string::npos) {
+        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, "Invalid IP:PORT.");
+        return;
+    }
+    std::string ip = ipPort.substr(0, colon);
+    int port = atoi(ipPort.substr(colon + 1).c_str());
+    if (ip.empty() || port <= 0 || port > 65535) {
+        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, "Invalid IP:PORT.");
+        return;
+    }
+
+    std::string pin = rawKeyboard("1234", "PIN (4-6 digitos)", 8);
+    if (pin.empty()) {
+        return;
+    }
+    bool pinOk = pin.size() >= 4 && pin.size() <= 6 &&
+        std::all_of(pin.begin(), pin.end(), [](unsigned char c) { return std::isdigit(c) != 0; });
+    if (!pinOk) {
+        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, "PIN must be 4-6 digits.");
+        return;
+    }
+
+    std::string error;
+    std::string dataType = Archive::mode() == MODE_SAVE ? "save" : "extdata";
+    bool ok = Transfer::sendBackup(title, backupPath, backupName, dataType, ip, (u16)port, pin, error);
+    if (ok) {
+        currentOverlay = std::make_shared<InfoOverlay>(*this, "Transfer completed.");
+    }
+    else {
+        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, error.empty() ? "Transfer failed." : error);
+    }
 }

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -812,7 +812,7 @@ void MainScreen::startTransferSend(void)
     std::string backupName = nameFromCell(cellIndex);
     std::u16string backupPath = Archive::mode() == MODE_SAVE ? title.fullSavePath(cellIndex) : title.fullExtdataPath(cellIndex);
 
-    std::string ipPort = rawKeyboard("192.168.1.10:8000", "IP:PUERTO del receptor", 32);
+    std::string ipPort = rawKeyboard("192.168.1.10:8000", "Receiver IP:PORT", 32);
     if (ipPort.empty()) {
         return;
     }
@@ -829,14 +829,16 @@ void MainScreen::startTransferSend(void)
         return;
     }
 
-    std::string pin = rawKeyboard("1234", "PIN (4-6 digitos)", 8);
+    std::string pin = rawKeyboard("1234", "PIN (4 digits)", 5);
     if (pin.empty()) {
         return;
     }
-    bool pinOk = pin.size() >= 4 && pin.size() <= 6 &&
+    // The receiver always generates a 4-digit PIN, so require exactly 4 here;
+    // a longer PIN could never match.
+    bool pinOk = pin.size() == 4 &&
         std::all_of(pin.begin(), pin.end(), [](unsigned char c) { return std::isdigit(c) != 0; });
     if (!pinOk) {
-        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, "PIN must be 4-6 digits.");
+        currentOverlay = std::make_shared<ErrorOverlay>(*this, -1, "PIN must be 4 digits.");
         return;
     }
 

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -227,24 +227,41 @@ void MainScreen::drawTop(void) const
         if (g_isTransferringFile) {
             C2D_DrawRectSolid(0, 0, 0.5f, 400, 240, COLOR_OVERLAY);
 
-            const float size = 0.7f;
-            std::string modeStr;
-            std::string mode = transferGetMode();
+            const float size     = 0.7f;
+            const float lineFeed = size * fontGetInfo(NULL)->lineFeed;
+            std::string mode     = transferGetMode();
             if (g_transferIsNetwork) {
+                // Two centered lines keep the (potentially long) mode label and the
+                // size readout on screen, matching the bottom progress modal.
                 u64 total = 0, done = 0;
                 transferGetProgress(done, total);
                 int pct            = total > 0 ? (int)((done * 100) / total) : 0;
                 std::string prefix = mode.empty() ? "Transferring backup" : mode;
-                modeStr = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
+                std::string line1  = StringUtils::format("%s... %d%%", prefix.c_str(), pct);
+                std::string line2  = transferBytesToMB(done, total);
+
+                float startY = ceilf((240 - 2 * lineFeed) / 2);
+
+                C2D_Text line1Text;
+                C2D_TextParse(&line1Text, dynamicBuf, line1.c_str());
+                C2D_TextOptimize(&line1Text);
+                C2D_DrawText(&line1Text, C2D_WithColor, ceilf((400 - StringUtils::textWidth(line1Text, size)) / 2), startY, 0.9f, size, size,
+                    COLOR_WHITE);
+
+                C2D_Text line2Text;
+                C2D_TextParse(&line2Text, dynamicBuf, line2.c_str());
+                C2D_TextOptimize(&line2Text);
+                C2D_DrawText(&line2Text, C2D_WithColor, ceilf((400 - StringUtils::textWidth(line2Text, size)) / 2), startY + lineFeed, 0.9f, size,
+                    size, COLOR_GREY_LIGHT);
             }
             else {
-                modeStr = (mode.empty() ? "Copying files" : mode) + " in progress...";
+                std::string modeStr = (mode.empty() ? "Copying files" : mode) + " in progress...";
+                C2D_Text modeText;
+                C2D_TextParse(&modeText, dynamicBuf, modeStr.c_str());
+                C2D_TextOptimize(&modeText);
+                C2D_DrawText(&modeText, C2D_WithColor, ceilf((400 - StringUtils::textWidth(modeText, size)) / 2), ceilf((240 - lineFeed) / 2), 0.9f,
+                    size, size, COLOR_WHITE);
             }
-            C2D_Text modeText;
-            C2D_TextParse(&modeText, dynamicBuf, modeStr.c_str());
-            C2D_TextOptimize(&modeText);
-            C2D_DrawText(&modeText, C2D_WithColor, ceilf((400 - StringUtils::textWidth(modeText, size)) / 2),
-                ceilf((240 - size * fontGetInfo(NULL)->lineFeed) / 2), 0.9f, size, size, COLOR_WHITE);
         }
     }
 }
@@ -341,7 +358,7 @@ void MainScreen::drawBottom(void) const
             C2D_DrawText(
                 &titleText, C2D_WithColor, ceilf(mx + (mw - StringUtils::textWidth(titleText, 0.55f)) / 2), my + 10, 0.5f, 0.55f, 0.55f, COLOR_WHITE);
 
-            std::string bytesStr = StringUtils::format("%llu / %llu", (unsigned long long)done, (unsigned long long)total);
+            std::string bytesStr = transferBytesToMB(done, total);
             C2D_Text bytesText;
             C2D_TextParse(&bytesText, dynamicBuf, bytesStr.c_str());
             C2D_TextOptimize(&bytesText);

--- a/3ds/source/MainScreen.cpp
+++ b/3ds/source/MainScreen.cpp
@@ -229,15 +229,16 @@ void MainScreen::drawTop(void) const
 
             const float size = 0.7f;
             std::string modeStr;
+            std::string mode = transferGetMode();
             if (g_transferIsNetwork) {
-                u64 total = g_transferBytesTotal;
-                u64 done  = g_transferBytesDone;
-                int pct   = total > 0 ? (int)((done * 100) / total) : 0;
-                std::string prefix = g_transferMode.empty() ? "Transferring backup" : g_transferMode;
+                u64 total = 0, done = 0;
+                transferGetProgress(done, total);
+                int pct            = total > 0 ? (int)((done * 100) / total) : 0;
+                std::string prefix = mode.empty() ? "Transferring backup" : mode;
                 modeStr = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
             }
             else {
-                modeStr = (g_transferMode.empty() ? "Copying files" : g_transferMode) + " in progress...";
+                modeStr = (mode.empty() ? "Copying files" : mode) + " in progress...";
             }
             C2D_Text modeText;
             C2D_TextParse(&modeText, dynamicBuf, modeStr.c_str());
@@ -327,10 +328,11 @@ void MainScreen::drawBottom(void) const
             C2D_DrawRectSolid(mx, my, 0.5f, mw, mh, COLOR_BLACK_DARKERR);
             Gui::drawOutline(mx, my, mw, mh, 2, COLOR_PURPLE_LIGHT);
 
-            u64 total = g_transferBytesTotal;
-            u64 done  = g_transferBytesDone;
-            int pct   = total > 0 ? (int)((done * 100) / total) : 0;
-            std::string prefix = g_transferMode.empty() ? "Transferring backup" : g_transferMode;
+            u64 total = 0, done = 0;
+            transferGetProgress(done, total);
+            int pct              = total > 0 ? (int)((done * 100) / total) : 0;
+            std::string mode     = transferGetMode();
+            std::string prefix   = mode.empty() ? "Transferring backup" : mode;
             std::string titleStr = StringUtils::format("%s... %d%%", prefix.c_str(), pct);
 
             C2D_Text titleText;
@@ -366,7 +368,8 @@ void MainScreen::drawBottom(void) const
             Gui::drawOutline(mx, my, mw, mh, 2, COLOR_PURPLE_LIGHT);
 
             // Title
-            std::string titleStr = (g_transferMode.empty() ? "Copying files" : g_transferMode) + " in progress...";
+            std::string mode     = transferGetMode();
+            std::string titleStr = (mode.empty() ? "Copying files" : mode) + " in progress...";
             C2D_Text titleText;
             C2D_TextParse(&titleText, dynamicBuf, titleStr.c_str());
             C2D_TextOptimize(&titleText);

--- a/3ds/source/TransferOverlay.cpp
+++ b/3ds/source/TransferOverlay.cpp
@@ -1,0 +1,167 @@
+/*
+ *   This file is part of Checkpoint
+ *   Copyright (C) 2017-2026 Bernardo Giordano, FlagBrew
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Additional Terms 7.b and 7.c of GPLv3 apply to this file:
+ *       * Requiring preservation of specified reasonable legal notices or
+ *         author attributions in that material or in the Appropriate Legal
+ *         Notices displayed by works containing it.
+ *       * Prohibiting misrepresentation of the origin of that material,
+ *         or requiring that modified versions of such material be marked in
+ *         reasonable ways as different from the original version.
+ */
+
+#include "TransferOverlay.hpp"
+#include "common.hpp"
+#include "main.hpp"
+#include "transfer.hpp"
+
+TransferMenuOverlay::TransferMenuOverlay(Screen& screen, const std::function<void()>& callbackSend, const std::function<void()>& callbackReceive)
+    : Overlay(screen), hid(2, 2)
+{
+    textBuf = C2D_TextBufNew(64);
+    C2D_TextParse(&text, textBuf, "Transferir backups");
+    C2D_TextOptimize(&text);
+
+    sendFunc    = callbackSend;
+    receiveFunc = callbackReceive;
+
+    posx = ceilf(320 - text.width * 0.6f) / 2;
+    posy = 40 + ceilf(120 - 0.6f * fontGetInfo(NULL)->lineFeed) / 2;
+
+    buttonSend    = std::make_unique<Clickable>(42, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE000 Enviar", true);
+    buttonReceive = std::make_unique<Clickable>(162, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE001 Recibir", true);
+}
+
+TransferMenuOverlay::~TransferMenuOverlay(void)
+{
+    C2D_TextBufDelete(textBuf);
+}
+
+void TransferMenuOverlay::drawTop(void) const
+{
+    C2D_DrawRectSolid(0, 0, 0.5f, 400, 240, COLOR_OVERLAY);
+}
+
+void TransferMenuOverlay::drawBottom(void) const
+{
+    C2D_DrawRectSolid(0, 0, 0.5f, 320, 240, COLOR_OVERLAY);
+    C2D_DrawRectSolid(40, 40, 0.5f, 240, 160, COLOR_BLACK_DARKER);
+    C2D_DrawText(&text, C2D_WithColor, posx, posy, 0.5f, 0.6f, 0.6f, COLOR_WHITE);
+    C2D_DrawRectSolid(40, 160, 0.5f, 240, 40, COLOR_BLACK_MEDIUM);
+
+    buttonSend->draw(0.7f, 0);
+    buttonReceive->draw(0.7f, 0);
+
+    if (hid.index() == 0) {
+        Gui::drawPulsingOutline(42, 162, 116, 36, 2, COLOR_PURPLE_DARK);
+    }
+    else {
+        Gui::drawPulsingOutline(162, 162, 116, 36, 2, COLOR_PURPLE_DARK);
+    }
+}
+
+void TransferMenuOverlay::update(const InputState& input)
+{
+    (void)input;
+    hid.update(2);
+
+    hid.index(buttonSend->held() ? 0 : buttonReceive->held() ? 1 : hid.index());
+    buttonSend->selected(hid.index() == 0);
+    buttonReceive->selected(hid.index() == 1);
+
+    if (buttonSend->released() || ((hidKeysDown() & KEY_A) && hid.index() == 0)) {
+        sendFunc();
+    }
+    else if (buttonReceive->released() || ((hidKeysDown() & KEY_A) && hid.index() == 1)) {
+        receiveFunc();
+    }
+    else if (hidKeysDown() & KEY_B) {
+        screen.removeOverlay();
+    }
+}
+
+ReceiveOverlay::ReceiveOverlay(Screen& screen) : Overlay(screen)
+{
+    textBuf = C2D_TextBufNew(256);
+}
+
+ReceiveOverlay::~ReceiveOverlay(void)
+{
+    C2D_TextBufDelete(textBuf);
+}
+
+void ReceiveOverlay::drawTop(void) const
+{
+    C2D_DrawRectSolid(0, 0, 0.5f, 400, 240, COLOR_OVERLAY);
+}
+
+void ReceiveOverlay::drawBottom(void) const
+{
+    C2D_TextBufClear(textBuf);
+    C2D_DrawRectSolid(0, 0, 0.5f, 320, 240, COLOR_OVERLAY);
+    C2D_DrawRectSolid(30, 40, 0.5f, 260, 160, COLOR_BLACK_DARKERR);
+
+    std::string info = "Receptor activo";
+    if (Transfer::receiverRunning()) {
+        info = StringUtils::format("IP: %s\nPuerto: %d\nPIN: %s", Transfer::receiverIp().c_str(), Transfer::receiverPort(),
+            Transfer::receiverToken().c_str());
+    }
+    else {
+        info = "Receptor detenido";
+    }
+
+    C2D_Text infoText;
+    C2D_TextParse(&infoText, textBuf, info.c_str());
+    C2D_TextOptimize(&infoText);
+    C2D_DrawText(&infoText, C2D_WithColor, 40, 60, 0.5f, 0.55f, 0.55f, COLOR_WHITE);
+
+    int noticeY = 120;
+    if (g_transferIsNetwork && g_isTransferringFile) {
+        u64 total = g_transferBytesTotal;
+        u64 done  = g_transferBytesDone;
+        int pct   = total > 0 ? (int)((done * 100) / total) : 0;
+        std::string status = StringUtils::format("Recibiendo... %d%% (%llu / %llu)", pct, (unsigned long long)done, (unsigned long long)total);
+        C2D_Text statusText;
+        C2D_TextParse(&statusText, textBuf, status.c_str());
+        C2D_TextOptimize(&statusText);
+        C2D_DrawText(&statusText, C2D_WithColor, 40, 120, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
+        noticeY = 142;
+    }
+
+    std::string notice = Transfer::receiverNotice();
+    if (!notice.empty()) {
+        C2D_Text noticeText;
+        C2D_TextParse(&noticeText, textBuf, notice.c_str());
+        C2D_TextOptimize(&noticeText);
+        C2D_DrawText(&noticeText, C2D_WithColor, 40, noticeY, 0.5f, 0.45f, 0.45f, COLOR_GREY_LIGHT);
+    }
+
+    C2D_Text hintText;
+    C2D_TextParse(&hintText, textBuf, "B para salir");
+    C2D_TextOptimize(&hintText);
+    C2D_DrawText(&hintText, C2D_WithColor, 40, 170, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
+}
+
+void ReceiveOverlay::update(const InputState& input)
+{
+    (void)input;
+    if (hidKeysDown() & KEY_B) {
+        Transfer::stopReceiver();
+        Transfer::clearReceiverNotice();
+        screen.removeOverlay();
+    }
+}

--- a/3ds/source/TransferOverlay.cpp
+++ b/3ds/source/TransferOverlay.cpp
@@ -33,7 +33,7 @@ TransferMenuOverlay::TransferMenuOverlay(Screen& screen, const std::function<voi
     : Overlay(screen), hid(2, 2)
 {
     textBuf = C2D_TextBufNew(64);
-    C2D_TextParse(&text, textBuf, "Transferir backups");
+    C2D_TextParse(&text, textBuf, "Send Data");
     C2D_TextOptimize(&text);
 
     sendFunc    = callbackSend;
@@ -42,8 +42,8 @@ TransferMenuOverlay::TransferMenuOverlay(Screen& screen, const std::function<voi
     posx = ceilf(320 - text.width * 0.6f) / 2;
     posy = 40 + ceilf(120 - 0.6f * fontGetInfo(NULL)->lineFeed) / 2;
 
-    buttonSend    = std::make_unique<Clickable>(42, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE000 Enviar", true);
-    buttonReceive = std::make_unique<Clickable>(162, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE001 Recibir", true);
+    buttonSend    = std::make_unique<Clickable>(42, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE000 Send", true);
+    buttonReceive = std::make_unique<Clickable>(162, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE001 Receive", true);
 }
 
 TransferMenuOverlay::~TransferMenuOverlay(void)

--- a/3ds/source/TransferOverlay.cpp
+++ b/3ds/source/TransferOverlay.cpp
@@ -33,7 +33,7 @@ TransferMenuOverlay::TransferMenuOverlay(Screen& screen, const std::function<voi
     : Overlay(screen), hid(2, 2)
 {
     textBuf = C2D_TextBufNew(64);
-    C2D_TextParse(&text, textBuf, "Send Data");
+    C2D_TextParse(&text, textBuf, "Choose Send or Receive");
     C2D_TextOptimize(&text);
 
     sendFunc    = callbackSend;
@@ -42,7 +42,7 @@ TransferMenuOverlay::TransferMenuOverlay(Screen& screen, const std::function<voi
     posx = ceilf(320 - text.width * 0.6f) / 2;
     posy = 40 + ceilf(120 - 0.6f * fontGetInfo(NULL)->lineFeed) / 2;
 
-    buttonSend    = std::make_unique<Clickable>(42, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE000 Send", true);
+    buttonSend    = std::make_unique<Clickable>(42, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE005 Send", true);
     buttonReceive = std::make_unique<Clickable>(162, 162, 116, 36, COLOR_BLACK_DARKERR, COLOR_WHITE, "\uE001 Receive", true);
 }
 
@@ -77,19 +77,20 @@ void TransferMenuOverlay::drawBottom(void) const
 void TransferMenuOverlay::update(const InputState& input)
 {
     (void)input;
+    u32 kDown = hidKeysDown();
     hid.update(2);
 
     hid.index(buttonSend->held() ? 0 : buttonReceive->held() ? 1 : hid.index());
     buttonSend->selected(hid.index() == 0);
     buttonReceive->selected(hid.index() == 1);
 
-    if (buttonSend->released() || ((hidKeysDown() & KEY_A) && hid.index() == 0)) {
+    if ((kDown & KEY_R) || buttonSend->released() || ((kDown & KEY_A) && hid.index() == 0)) {
         sendFunc();
     }
-    else if (buttonReceive->released() || ((hidKeysDown() & KEY_A) && hid.index() == 1)) {
+    else if ((kDown & KEY_B) || buttonReceive->released() || ((kDown & KEY_A) && hid.index() == 1)) {
         receiveFunc();
     }
-    else if (hidKeysDown() & KEY_B) {
+    else if (kDown & KEY_START) {
         screen.removeOverlay();
     }
 }
@@ -114,6 +115,38 @@ void ReceiveOverlay::drawBottom(void) const
     C2D_TextBufClear(textBuf);
     C2D_DrawRectSolid(0, 0, 0.5f, 320, 240, COLOR_OVERLAY);
     C2D_DrawRectSolid(30, 40, 0.5f, 260, 160, COLOR_BLACK_DARKERR);
+
+    bool completed = Transfer::receiverHasCompleted();
+    if (completed && !(g_transferIsNetwork && g_isTransferringFile)) {
+        std::string backupName = Transfer::receiverCompletedName();
+        if (backupName.empty()) {
+            backupName = "(unnamed backup)";
+        }
+
+        C2D_Text titleText;
+        C2D_TextParse(&titleText, textBuf, "File received");
+        C2D_TextOptimize(&titleText);
+        C2D_DrawText(&titleText, C2D_WithColor, 40, 60, 0.5f, 0.65f, 0.65f, COLOR_WHITE);
+
+        C2D_Text nameText;
+        C2D_TextParse(&nameText, textBuf, backupName.c_str());
+        C2D_TextOptimize(&nameText);
+        C2D_DrawText(&nameText, C2D_WithColor, 40, 92, 0.5f, 0.52f, 0.52f, COLOR_GREY_LIGHT);
+
+        std::string notice = Transfer::receiverNotice();
+        if (!notice.empty()) {
+            C2D_Text noticeText;
+            C2D_TextParse(&noticeText, textBuf, notice.c_str());
+            C2D_TextOptimize(&noticeText);
+            C2D_DrawText(&noticeText, C2D_WithColor, 40, 122, 0.5f, 0.45f, 0.45f, COLOR_GREY_LIGHT);
+        }
+
+        C2D_Text hintText;
+        C2D_TextParse(&hintText, textBuf, "Press A (OK) to refresh now");
+        C2D_TextOptimize(&hintText);
+        C2D_DrawText(&hintText, C2D_WithColor, 40, 170, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
+        return;
+    }
 
     std::string info = "Receiver active";
     if (Transfer::receiverRunning()) {
@@ -160,8 +193,16 @@ void ReceiveOverlay::drawBottom(void) const
 void ReceiveOverlay::update(const InputState& input)
 {
     (void)input;
+    if (Transfer::receiverHasCompleted() && (hidKeysDown() & KEY_A)) {
+        Transfer::stopReceiver();
+        Transfer::clearReceiverCompletion();
+        Transfer::clearReceiverNotice();
+        screen.removeOverlay();
+        return;
+    }
     if (hidKeysDown() & KEY_B) {
         Transfer::stopReceiver();
+        Transfer::clearReceiverCompletion();
         Transfer::clearReceiverNotice();
         screen.removeOverlay();
     }

--- a/3ds/source/TransferOverlay.cpp
+++ b/3ds/source/TransferOverlay.cpp
@@ -115,13 +115,13 @@ void ReceiveOverlay::drawBottom(void) const
     C2D_DrawRectSolid(0, 0, 0.5f, 320, 240, COLOR_OVERLAY);
     C2D_DrawRectSolid(30, 40, 0.5f, 260, 160, COLOR_BLACK_DARKERR);
 
-    std::string info = "Receptor activo";
+    std::string info = "Receiver active";
     if (Transfer::receiverRunning()) {
-        info = StringUtils::format("IP: %s\nPuerto: %d\nPIN: %s", Transfer::receiverIp().c_str(), Transfer::receiverPort(),
+        info = StringUtils::format("IP: %s\nPort: %d\nPIN: %s", Transfer::receiverIp().c_str(), Transfer::receiverPort(),
             Transfer::receiverToken().c_str());
     }
     else {
-        info = "Receptor detenido";
+        info = "Receiver stopped";
     }
 
     C2D_Text infoText;
@@ -134,7 +134,8 @@ void ReceiveOverlay::drawBottom(void) const
         u64 total = g_transferBytesTotal;
         u64 done  = g_transferBytesDone;
         int pct   = total > 0 ? (int)((done * 100) / total) : 0;
-        std::string status = StringUtils::format("Recibiendo... %d%% (%llu / %llu)", pct, (unsigned long long)done, (unsigned long long)total);
+        std::string prefix = g_transferMode.empty() ? "Downloading backup" : g_transferMode;
+        std::string status = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
         C2D_Text statusText;
         C2D_TextParse(&statusText, textBuf, status.c_str());
         C2D_TextOptimize(&statusText);
@@ -151,7 +152,7 @@ void ReceiveOverlay::drawBottom(void) const
     }
 
     C2D_Text hintText;
-    C2D_TextParse(&hintText, textBuf, "B para salir");
+    C2D_TextParse(&hintText, textBuf, "Press B to close");
     C2D_TextOptimize(&hintText);
     C2D_DrawText(&hintText, C2D_WithColor, 40, 170, 0.5f, 0.5f, 0.5f, COLOR_GREY_LIGHT);
 }

--- a/3ds/source/TransferOverlay.cpp
+++ b/3ds/source/TransferOverlay.cpp
@@ -169,7 +169,7 @@ void ReceiveOverlay::drawBottom(void) const
         int pct            = total > 0 ? (int)((done * 100) / total) : 0;
         std::string mode   = transferGetMode();
         std::string prefix = mode.empty() ? "Downloading backup" : mode;
-        std::string status = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
+        std::string status = StringUtils::format("%s... %d%% (%s)", prefix.c_str(), pct, transferBytesToMB(done, total).c_str());
         C2D_Text statusText;
         C2D_TextParse(&statusText, textBuf, status.c_str());
         C2D_TextOptimize(&statusText);

--- a/3ds/source/TransferOverlay.cpp
+++ b/3ds/source/TransferOverlay.cpp
@@ -164,10 +164,11 @@ void ReceiveOverlay::drawBottom(void) const
 
     int noticeY = 120;
     if (g_transferIsNetwork && g_isTransferringFile) {
-        u64 total = g_transferBytesTotal;
-        u64 done  = g_transferBytesDone;
-        int pct   = total > 0 ? (int)((done * 100) / total) : 0;
-        std::string prefix = g_transferMode.empty() ? "Downloading backup" : g_transferMode;
+        u64 total = 0, done = 0;
+        transferGetProgress(done, total);
+        int pct            = total > 0 ? (int)((done * 100) / total) : 0;
+        std::string mode   = transferGetMode();
+        std::string prefix = mode.empty() ? "Downloading backup" : mode;
         std::string status = StringUtils::format("%s... %d%% (%llu / %llu)", prefix.c_str(), pct, (unsigned long long)done, (unsigned long long)total);
         C2D_Text statusText;
         C2D_TextParse(&statusText, textBuf, status.c_str());

--- a/3ds/source/io.cpp
+++ b/3ds/source/io.cpp
@@ -256,7 +256,7 @@ std::tuple<bool, Result, std::string> io::backup(size_t index, size_t cellIndex)
 
             g_copyCount    = 0;
             g_copyTotal    = io::countFiles(archive, StringUtils::UTF8toUTF16("/"));
-            g_transferMode = "Backup";
+            transferSetMode("Backup");
 
             res = io::copyDirectory(archive, Archive::sdmc(), StringUtils::UTF8toUTF16("/"), copyPath);
             if (R_FAILED(res)) {
@@ -387,7 +387,7 @@ std::tuple<bool, Result, std::string> io::restore(size_t index, size_t cellIndex
 
             g_copyCount    = 0;
             g_copyTotal    = io::countFiles(Archive::sdmc(), srcPath);
-            g_transferMode = "Restore";
+            transferSetMode("Restore");
 
             res = io::copyDirectory(Archive::sdmc(), archive, srcPath, dstPath);
             if (R_FAILED(res)) {

--- a/3ds/source/loader.cpp
+++ b/3ds/source/loader.cpp
@@ -90,6 +90,24 @@ void TitleLoader::getTitle(Title& dst, int i)
     }
 }
 
+bool TitleLoader::getTitleById(Title& dst, u64 id)
+{
+    std::lock_guard<std::mutex> lock(titlesMutex);
+    for (const auto& title : titleSaves) {
+        if (title.id() == id) {
+            dst = title;
+            return true;
+        }
+    }
+    for (const auto& title : titleExtdatas) {
+        if (title.id() == id) {
+            dst = title;
+            return true;
+        }
+    }
+    return false;
+}
+
 int TitleLoader::getTitleCount(void)
 {
     const Mode_t mode = Archive::mode();
@@ -125,20 +143,15 @@ bool TitleLoader::favorite(int i)
 
 void TitleLoader::refreshDirectories(u64 id)
 {
-    const Mode_t mode = Archive::mode();
     std::lock_guard<std::mutex> lock(titlesMutex);
-    if (mode == MODE_SAVE) {
-        for (size_t i = 0; i < titleSaves.size(); i++) {
-            if (titleSaves.at(i).id() == id) {
-                titleSaves.at(i).refreshDirectories();
-            }
+    for (size_t i = 0; i < titleSaves.size(); i++) {
+        if (titleSaves.at(i).id() == id) {
+            titleSaves.at(i).refreshDirectories();
         }
     }
-    else {
-        for (size_t i = 0; i < titleExtdatas.size(); i++) {
-            if (titleExtdatas.at(i).id() == id) {
-                titleExtdatas.at(i).refreshDirectories();
-            }
+    for (size_t i = 0; i < titleExtdatas.size(); i++) {
+        if (titleExtdatas.at(i).id() == id) {
+            titleExtdatas.at(i).refreshDirectories();
         }
     }
 }

--- a/3ds/source/loader.cpp
+++ b/3ds/source/loader.cpp
@@ -28,6 +28,7 @@
 #include "main.hpp"
 #include "title.hpp"
 #include <chrono>
+#include <cctype>
 #include <mutex>
 
 namespace {
@@ -38,6 +39,15 @@ namespace {
     bool forceRefresh           = false;
     std::atomic_flag doCartScan = ATOMIC_FLAG_INIT;
     const size_t ENTRYSIZE      = 5341;
+
+    std::string toLowerAscii(const std::string& s)
+    {
+        std::string out = s;
+        for (size_t i = 0; i < out.size(); i++) {
+            out[i] = (char)std::tolower((unsigned char)out[i]);
+        }
+        return out;
+    }
 }
 
 bool TitleLoader::validId(u64 id)
@@ -108,6 +118,29 @@ bool TitleLoader::getTitleById(Title& dst, u64 id)
     return false;
 }
 
+bool TitleLoader::getTitleByName(Title& dst, const std::string& name)
+{
+    if (name.empty()) {
+        return false;
+    }
+
+    std::string needle = toLowerAscii(name);
+    std::lock_guard<std::mutex> lock(titlesMutex);
+    for (const auto& title : titleSaves) {
+        if (toLowerAscii(title.shortDescription()) == needle) {
+            dst = title;
+            return true;
+        }
+    }
+    for (const auto& title : titleExtdatas) {
+        if (toLowerAscii(title.shortDescription()) == needle) {
+            dst = title;
+            return true;
+        }
+    }
+    return false;
+}
+
 int TitleLoader::getTitleCount(void)
 {
     const Mode_t mode = Archive::mode();
@@ -153,6 +186,17 @@ void TitleLoader::refreshDirectories(u64 id)
         if (titleExtdatas.at(i).id() == id) {
             titleExtdatas.at(i).refreshDirectories();
         }
+    }
+}
+
+void TitleLoader::refreshAllDirectories(void)
+{
+    std::lock_guard<std::mutex> lock(titlesMutex);
+    for (auto& title : titleSaves) {
+        title.refreshDirectories();
+    }
+    for (auto& title : titleExtdatas) {
+        title.refreshDirectories();
     }
 }
 

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -108,7 +108,7 @@ namespace {
                     if (path == "/transfer/upload") {
                         trackTransfer = true;
                         g_transferIsNetwork = true;
-                        g_transferMode = "Recibiendo";
+                        g_transferMode = "Downloading backup";
                         g_transferBytesTotal = contentLength;
                         g_transferBytesDone = 0;
                         g_isTransferringFile = true;

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "server.hpp"
+#include "main.hpp"
 #include "logging.hpp"
 #include "thread.hpp"
 #include <3ds.h>
@@ -33,6 +34,7 @@
 #include <string>
 
 #include <arpa/inet.h>
+#include <cstdlib>
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -59,16 +61,85 @@ namespace {
         return "";
     }
 
+    static size_t parseContentLength(const std::string& headers)
+    {
+        size_t pos = headers.find("Content-Length:");
+        if (pos == std::string::npos) {
+            pos = headers.find("Content-length:");
+        }
+        if (pos == std::string::npos) {
+            return 0;
+        }
+        pos += strlen("Content-Length:");
+        while (pos < headers.size() && (headers[pos] == ' ' || headers[pos] == '\t')) {
+            pos++;
+        }
+        size_t end = headers.find("\r\n", pos);
+        if (end == std::string::npos) {
+            end = headers.size();
+        }
+        return (size_t)strtoul(headers.substr(pos, end - pos).c_str(), nullptr, 10);
+    }
+
+    static std::string readRequest(s32 clientSocket)
+    {
+        std::string data;
+        data.reserve(4096);
+        char buffer[2048];
+        ssize_t received = 0;
+        size_t headerEnd = std::string::npos;
+        size_t contentLength = 0;
+        std::string path;
+        bool trackTransfer = false;
+
+        while (true) {
+            received = recv(clientSocket, buffer, sizeof(buffer), 0);
+            if (received <= 0) {
+                break;
+            }
+            data.append(buffer, received);
+
+            if (headerEnd == std::string::npos) {
+                headerEnd = data.find("\r\n\r\n");
+                if (headerEnd != std::string::npos) {
+                    contentLength = parseContentLength(data.substr(0, headerEnd));
+                    path = extractPath(data.substr(0, headerEnd));
+                    if (path == "/transfer/upload") {
+                        trackTransfer = true;
+                        g_transferIsNetwork = true;
+                        g_transferMode = "Recibiendo";
+                        g_transferBytesTotal = contentLength;
+                        g_transferBytesDone = 0;
+                        g_isTransferringFile = true;
+                    }
+                    if (contentLength == 0) {
+                        break;
+                    }
+                }
+            }
+
+            if (headerEnd != std::string::npos) {
+                size_t totalNeeded = headerEnd + 4 + contentLength;
+                if (trackTransfer && data.size() > headerEnd + 4) {
+                    g_transferBytesDone = data.size() - (headerEnd + 4);
+                }
+                if (data.size() >= totalNeeded) {
+                    break;
+                }
+            }
+        }
+
+        return data;
+    }
+
     static void handleHttpRequest(s32 clientSocket)
     {
-        char buffer[1024] = {0};
-        recv(clientSocket, buffer, sizeof(buffer) - 1, 0);
-        std::string request(buffer);
+        std::string request = readRequest(clientSocket);
         std::string path = extractPath(request);
-        auto it          = handlers.find(path);
+        auto it = handlers.find(path);
         if (it != handlers.end()) {
             Server::HttpResponse response = it->second(path, request);
-            std::string header            = "HTTP/1.1 " + std::to_string(response.statusCode);
+            std::string header = "HTTP/1.1 " + std::to_string(response.statusCode);
             header += (response.statusCode == 200 ? " OK" : (response.statusCode == 404 ? " Not Found" : " Error"));
             header += "\r\nContent-Type: " + response.contentType;
             header += "\r\nContent-Length: " + std::to_string(response.body.length());

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -34,6 +34,7 @@
 #include <string>
 
 #include <arpa/inet.h>
+#include <atomic>
 #include <cstdlib>
 #include <fcntl.h>
 #include <netinet/in.h>
@@ -44,7 +45,7 @@ namespace {
     static const int SERVER_PORT   = 8000;
     std::atomic_flag serverRunning = ATOMIC_FLAG_INIT;
     s32 serverSocket               = -1;
-    bool isRunning                 = false;
+    std::atomic<bool> serverIsRunning{false};
     std::string serverAddress;
 
     std::map<std::string, Server::HttpHandler> handlers;
@@ -163,7 +164,7 @@ namespace {
         // Set server socket to non-blocking
         fcntl(serverSocket, F_SETFL, fcntl(serverSocket, F_GETFL, 0) | O_NONBLOCK);
 
-        isRunning = true;
+        serverIsRunning.store(true);
         while (serverRunning.test_and_set()) {
             s32 clientSocket = accept(serverSocket, (struct sockaddr*)&clientAddr, &clientLen);
 
@@ -180,6 +181,8 @@ namespace {
             // Prevent 100% CPU usage
             svcSleepThread(100000000); // 100ms
         }
+
+        serverIsRunning.store(false);
     }
 }
 
@@ -197,7 +200,7 @@ void Server::unregisterHandler(const std::string& path)
 
 bool Server::isRunning(void)
 {
-    return isRunning;
+    return serverIsRunning.load();
 }
 
 std::string Server::getAddress(void)
@@ -243,6 +246,7 @@ void Server::init()
 
 void Server::exit()
 {
+    serverIsRunning.store(false);
     serverRunning.clear();
 
     if (serverSocket >= 0) {

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -31,6 +31,7 @@
 #include <3ds.h>
 #include <cstring>
 #include <map>
+#include <mutex>
 #include <string>
 
 #include <arpa/inet.h>
@@ -54,6 +55,9 @@ namespace {
     std::string serverAddress;
 
     std::map<std::string, Server::HttpHandler> handlers;
+    // handlers is mutated from the main thread (register/unregister on receiver
+    // start/stop) while the network thread looks handlers up, so guard it.
+    std::mutex handlersMutex;
 
     std::string extractPath(const std::string& request)
     {
@@ -180,9 +184,18 @@ namespace {
             return;
         }
         std::string path = extractPath(request);
-        auto it = handlers.find(path);
-        if (it != handlers.end()) {
-            Server::HttpResponse response = it->second(path, request);
+        Server::HttpHandler handler;
+        bool found = false;
+        {
+            std::lock_guard<std::mutex> lock(handlersMutex);
+            auto it = handlers.find(path);
+            if (it != handlers.end()) {
+                handler = it->second;
+                found   = true;
+            }
+        }
+        if (found) {
+            Server::HttpResponse response = handler(path, request);
             std::string header = "HTTP/1.1 " + std::to_string(response.statusCode);
             header += (response.statusCode == 200 ? " OK" : (response.statusCode == 404 ? " Not Found" : " Error"));
             header += "\r\nContent-Type: " + response.contentType;
@@ -231,13 +244,19 @@ namespace {
 
 void Server::registerHandler(const std::string& path, Server::HttpHandler handler)
 {
-    handlers[path] = handler;
+    {
+        std::lock_guard<std::mutex> lock(handlersMutex);
+        handlers[path] = handler;
+    }
     Logging::info("Registered HTTP handler for path {}", path);
 }
 
 void Server::unregisterHandler(const std::string& path)
 {
-    handlers.erase(path);
+    {
+        std::lock_guard<std::mutex> lock(handlersMutex);
+        handlers.erase(path);
+    }
     Logging::info("Unregistered HTTP handler for path {}", path);
 }
 
@@ -297,7 +316,10 @@ void Server::exit()
         serverSocket = -1;
     }
 
-    handlers.clear();
+    {
+        std::lock_guard<std::mutex> lock(handlersMutex);
+        handlers.clear();
+    }
 
     Logging::trace("HTTP server stopped");
 }

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -138,9 +138,8 @@ namespace {
                     if (path == "/transfer/upload") {
                         trackTransfer = true;
                         g_transferIsNetwork = true;
-                        g_transferMode = "Downloading backup";
-                        g_transferBytesTotal = contentLength;
-                        g_transferBytesDone = 0;
+                        transferSetMode("Downloading backup");
+                        transferSetProgress(0, contentLength);
                         g_isTransferringFile = true;
                     }
                     if (contentLength == 0) {
@@ -154,7 +153,7 @@ namespace {
                 // is bounded too: we stop as soon as the declared body has arrived.
                 size_t totalNeeded = headerEnd + 4 + contentLength;
                 if (trackTransfer && data.size() > headerEnd + 4) {
-                    g_transferBytesDone = data.size() - (headerEnd + 4);
+                    transferSetDone(data.size() - (headerEnd + 4));
                 }
                 if (data.size() >= totalNeeded) {
                     break;

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -42,8 +42,12 @@
 #include <unistd.h>
 
 namespace {
-    static const int SERVER_PORT   = 8000;
-    std::atomic_flag serverRunning = ATOMIC_FLAG_INIT;
+    static const int SERVER_PORT = 8000;
+    // Hard upper bound on a single request we are willing to buffer in RAM.
+    // The whole request is held in memory, so this caps worst-case allocation
+    // and prevents a malformed/malicious Content-Length from exhausting the heap.
+    static const size_t MAX_REQUEST_SIZE = 32 * 1024 * 1024;
+    std::atomic_flag serverRunning       = ATOMIC_FLAG_INIT;
     s32 serverSocket               = -1;
     std::atomic<bool> serverIsRunning{false};
     std::string serverAddress;
@@ -82,13 +86,14 @@ namespace {
         return (size_t)strtoul(headers.substr(pos, end - pos).c_str(), nullptr, 10);
     }
 
-    static std::string readRequest(s32 clientSocket)
+    static std::string readRequest(s32 clientSocket, bool& outTooLarge)
     {
+        outTooLarge = false;
         std::string data;
         data.reserve(4096);
         char buffer[2048];
-        ssize_t received = 0;
-        size_t headerEnd = std::string::npos;
+        ssize_t received     = 0;
+        size_t headerEnd     = std::string::npos;
         size_t contentLength = 0;
         std::string path;
         bool trackTransfer = false;
@@ -101,10 +106,20 @@ namespace {
             data.append(buffer, received);
 
             if (headerEnd == std::string::npos) {
+                // No header terminator yet: guard against a client that never
+                // sends one (or buries it past the cap) and grows us unbounded.
+                if (data.size() > MAX_REQUEST_SIZE) {
+                    outTooLarge = true;
+                    break;
+                }
                 headerEnd = data.find("\r\n\r\n");
                 if (headerEnd != std::string::npos) {
                     contentLength = parseContentLength(data.substr(0, headerEnd));
-                    path = extractPath(data.substr(0, headerEnd));
+                    path          = extractPath(data.substr(0, headerEnd));
+                    if (contentLength > MAX_REQUEST_SIZE) {
+                        outTooLarge = true;
+                        break;
+                    }
                     if (path == "/transfer/upload") {
                         trackTransfer = true;
                         g_transferIsNetwork = true;
@@ -120,6 +135,8 @@ namespace {
             }
 
             if (headerEnd != std::string::npos) {
+                // contentLength is bounded by MAX_REQUEST_SIZE above, so this read
+                // is bounded too: we stop as soon as the declared body has arrived.
                 size_t totalNeeded = headerEnd + 4 + contentLength;
                 if (trackTransfer && data.size() > headerEnd + 4) {
                     g_transferBytesDone = data.size() - (headerEnd + 4);
@@ -135,7 +152,19 @@ namespace {
 
     static void handleHttpRequest(s32 clientSocket)
     {
-        std::string request = readRequest(clientSocket);
+        bool tooLarge        = false;
+        std::string request  = readRequest(clientSocket, tooLarge);
+        if (tooLarge) {
+            // Reset any transfer UI state we may have set while reading headers.
+            g_isTransferringFile = false;
+            g_transferIsNetwork  = false;
+            std::string body   = "{\"ok\":false,\"error\":\"Payload too large\"}";
+            std::string header = "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\nContent-Length: " +
+                                 std::to_string(body.length()) + "\r\n\r\n";
+            send(clientSocket, header.c_str(), header.length(), 0);
+            send(clientSocket, body.c_str(), body.length(), 0);
+            return;
+        }
         std::string path = extractPath(request);
         auto it = handlers.find(path);
         if (it != handlers.end()) {

--- a/3ds/source/server.cpp
+++ b/3ds/source/server.cpp
@@ -38,6 +38,7 @@
 #include <cstdlib>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -86,6 +87,11 @@ namespace {
         return (size_t)strtoul(headers.substr(pos, end - pos).c_str(), nullptr, 10);
     }
 
+    // Per-recv idle timeout. The server is single-threaded, so without a bound a
+    // stalled (or malicious) client would hang the whole receiver indefinitely.
+    // The 3DS SOC layer doesn't support SO_RCVTIMEO, so we gate recv with poll.
+    static const int RECV_TIMEOUT_MS = 15000;
+
     static std::string readRequest(s32 clientSocket, bool& outTooLarge)
     {
         outTooLarge = false;
@@ -99,6 +105,15 @@ namespace {
         bool trackTransfer = false;
 
         while (true) {
+            struct pollfd pfd;
+            pfd.fd      = clientSocket;
+            pfd.events  = POLLIN;
+            pfd.revents = 0;
+            int ready   = poll(&pfd, 1, RECV_TIMEOUT_MS);
+            if (ready <= 0) {
+                // Timed out or poll error: abandon this (possibly stalled) request.
+                break;
+            }
             received = recv(clientSocket, buffer, sizeof(buffer), 0);
             if (received <= 0) {
                 break;

--- a/3ds/source/title.cpp
+++ b/3ds/source/title.cpp
@@ -270,7 +270,7 @@ std::string Title::mediaTypeString(void)
     return " ";
 }
 
-std::string Title::shortDescription(void)
+std::string Title::shortDescription(void) const
 {
     return StringUtils::UTF16toUTF8(mShortDescription);
 }
@@ -463,7 +463,7 @@ u32 Title::uniqueId(void)
     return (lowId() >> 8);
 }
 
-u64 Title::id(void)
+u64 Title::id(void) const
 {
     return mId;
 }

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -49,8 +49,7 @@
 
 namespace {
     static const int TRANSFER_PORT = 8000;
-    [[maybe_unused]] static const char* TEMP_ZIP_SEND = "sdmc:/3ds/Checkpoint/transfer_send.zip";
-    [[maybe_unused]] static const char* TEMP_ZIP_RECV = "sdmc:/3ds/Checkpoint/transfer_recv.zip";
+    static const char* TEMP_ZIP_RECV = "sdmc:/3ds/Checkpoint/transfer_recv.zip";
 
     std::string g_token;
     std::string g_receiverIp;
@@ -74,6 +73,15 @@ namespace {
 
     u32 crcTable[256];
     bool crcInit = false;
+
+    void renderTransferFrame(void)
+    {
+        C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+        g_screen->drawTop();
+        C2D_SceneBegin(g_bottom);
+        g_screen->drawBottom();
+        Gui::frameEnd();
+    }
 
     void initCrc(void)
     {
@@ -153,6 +161,15 @@ namespace {
         }
     }
 
+    u32 totalFileBytes(const std::vector<FileEntry>& files)
+    {
+        u32 total = 0;
+        for (const auto& entry : files) {
+            total += entry.size;
+        }
+        return total;
+    }
+
     void writeLe16(FSStream& out, u16 v)
     {
         u8 b[2] = { (u8)(v & 0xFF), (u8)((v >> 8) & 0xFF) };
@@ -165,11 +182,12 @@ namespace {
         out.write(b, 4);
     }
 
-    [[maybe_unused]] bool writeZip(const std::u16string& root, const std::u16string& zipPath, std::vector<FileEntry>& files, u32& outZipSize)
+    bool writeZip(const std::u16string& root, const std::u16string& zipPath, std::vector<FileEntry>& files, u32& outZipSize, std::string& outError)
     {
         files.clear();
         collectFiles(Archive::sdmc(), root, StringUtils::UTF8toUTF16(""), files);
         if (files.empty()) {
+            outError = "No files found to package.";
             return false;
         }
 
@@ -186,6 +204,7 @@ namespace {
 
         FSStream output(Archive::sdmc(), zipPath, FS_OPEN_WRITE, total);
         if (!output.good()) {
+            outError = StringUtils::format("Cannot create package file (0x%08lX).", output.result());
             return false;
         }
 
@@ -218,6 +237,7 @@ namespace {
             FSStream input(Archive::sdmc(), entry.absPath, FS_OPEN_READ);
             if (!input.good()) {
                 output.close();
+                outError = StringUtils::format("Cannot read source file for packaging (0x%08lX).", input.result());
                 return false;
             }
             while (!input.eof()) {
@@ -226,6 +246,8 @@ namespace {
                     break;
                 }
                 output.write(buf.get(), rd);
+                g_transferBytesDone += rd;
+                renderTransferFrame();
             }
             input.close();
 
@@ -308,7 +330,39 @@ namespace {
         return true;
     }
 
-    [[maybe_unused]] bool extractZip(const std::u16string& zipPath, const std::u16string& destRoot, std::string& outError)
+    bool isSafeZipRelativePath(const std::string& relPath)
+    {
+        if (relPath.empty()) {
+            return false;
+        }
+        if (relPath.front() == '/' || relPath.front() == '\\') {
+            return false;
+        }
+        if (relPath.find('\\') != std::string::npos) {
+            return false;
+        }
+        if (relPath.find(':') != std::string::npos) {
+            return false;
+        }
+
+        size_t start = 0;
+        while (start <= relPath.size()) {
+            size_t pos = relPath.find('/', start);
+            size_t len = (pos == std::string::npos) ? relPath.size() - start : pos - start;
+            std::string part = relPath.substr(start, len);
+            if (part == "..") {
+                return false;
+            }
+            if (pos == std::string::npos) {
+                break;
+            }
+            start = pos + 1;
+        }
+
+        return true;
+    }
+
+    bool extractZip(const std::u16string& zipPath, const std::u16string& destRoot, std::string& outError)
     {
         FSStream input(Archive::sdmc(), zipPath, FS_OPEN_READ);
         if (!input.good()) {
@@ -345,6 +399,12 @@ namespace {
 
             if (compression != 0 || (flags & 0x08)) {
                 outError = "Unsupported ZIP compression.";
+                input.close();
+                return false;
+            }
+
+            if (!isSafeZipRelativePath(name)) {
+                outError = "Invalid ZIP entry path.";
                 input.close();
                 return false;
             }
@@ -514,6 +574,7 @@ namespace {
         std::string titleId = meta.value("titleId", "");
         std::string titleName = meta.value("titleName", "Unknown");
         std::string backupName = meta.value("backupName", "");
+        bool isZip = meta.value("isZip", false);
         if (backupName.empty()) {
             backupName = "Received_" + DateTime::dateTimeStr();
         }
@@ -527,14 +588,10 @@ namespace {
             tid = strtoull(titleId.c_str(), nullptr, 16);
         }
         if (tid != 0) {
-            for (int i = 0; i < TitleLoader::getTitleCount(); i++) {
-                Title t;
-                TitleLoader::getTitle(t, i);
-                if (t.id() == tid) {
-                    destRoot = (dataType == "extdata") ? t.extdataPath() : t.savePath();
-                    foundTitle = true;
-                    break;
-                }
+            Title t;
+            if (TitleLoader::getTitleById(t, tid)) {
+                destRoot = (dataType == "extdata") ? t.extdataPath() : t.savePath();
+                foundTitle = true;
             }
         }
 
@@ -548,7 +605,7 @@ namespace {
             if (!io::directoryExists(Archive::sdmc(), destRoot)) {
                 io::createDirectory(Archive::sdmc(), destRoot);
             }
-            g_receiverNotice = "Aviso: titulo desconocido. Backup guardado en carpeta generica.";
+            g_receiverNotice = "Warning: unknown title. Backup stored in a generic folder.";
             Logging::warning("Received backup for unknown title {} (stored under {}).", titleId, StringUtils::UTF16toUTF8(destRoot));
         }
 
@@ -559,19 +616,28 @@ namespace {
         }
         io::createDirectory(Archive::sdmc(), backupRoot);
 
-        std::string fileName = meta.value("fileName", "");
-        if (fileName.empty()) {
-            fileName = "received.bin";
+        std::u16string outputPath;
+        if (isZip) {
+            outputPath = StringUtils::UTF8toUTF16(TEMP_ZIP_RECV);
+            if (io::fileExists(Archive::sdmc(), outputPath)) {
+                FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, outputPath.data()));
+            }
         }
-        std::u16string safeFileName = StringUtils::removeForbiddenCharacters(StringUtils::UTF8toUTF16(fileName.c_str()));
-        std::string safeFileNameUtf8 = StringUtils::UTF16toUTF8(safeFileName);
-        if (safeFileNameUtf8.empty()) {
-            safeFileNameUtf8 = "received.bin";
-            safeFileName = StringUtils::UTF8toUTF16("received.bin");
+        else {
+            std::string fileName = meta.value("fileName", "");
+            if (fileName.empty()) {
+                fileName = "received.bin";
+            }
+            std::u16string safeFileName = StringUtils::removeForbiddenCharacters(StringUtils::UTF8toUTF16(fileName.c_str()));
+            std::string safeFileNameUtf8 = StringUtils::UTF16toUTF8(safeFileName);
+            if (safeFileNameUtf8.empty()) {
+                safeFileNameUtf8 = "received.bin";
+                safeFileName = StringUtils::UTF8toUTF16("received.bin");
+            }
+            ensureDirectoryPath(backupRoot, safeFileNameUtf8);
+            outputPath = backupRoot + safeFileName;
         }
-        ensureDirectoryPath(backupRoot, safeFileNameUtf8);
 
-        std::u16string outputPath = backupRoot + safeFileName;
         FSStream output(Archive::sdmc(), outputPath, FS_OPEN_WRITE, (u32)fileData.size());
         if (!output.good()) {
             cleanup();
@@ -581,6 +647,25 @@ namespace {
             output.write(fileData.data(), (u32)fileData.size());
         }
         output.close();
+
+        if (isZip) {
+            g_transferMode = "Extracting package";
+            g_transferIsNetwork = true;
+            g_transferBytesTotal = (u32)fileData.size();
+            g_transferBytesDone = 0;
+
+            std::string extractError;
+            bool extracted = extractZip(outputPath, backupRoot, extractError);
+            FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, outputPath.data()));
+
+            if (!extracted) {
+                cleanup();
+                std::string message = extractError.empty() ? "Failed to extract package." : extractError;
+                return {500, "application/json", "{\"ok\":false,\"error\":\"" + message + "\"}"};
+            }
+
+            g_transferBytesDone = g_transferBytesTotal;
+        }
 
         cleanup();
 
@@ -688,16 +773,55 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         outError = "No files to send.";
         return false;
     }
-    if (files.size() != 1) {
-        outError = "Multiple files found. ZIP transfer required.";
-        return false;
+
+    bool isZip = files.size() > 1;
+    std::u16string payloadPath;
+    std::string payloadName;
+    u32 payloadSize = 0;
+
+    auto clearTransferState = []() {
+        g_isTransferringFile = false;
+        g_transferIsNetwork  = false;
+    };
+
+    if (isZip) {
+        g_transferMode = "Preparing backup package";
+        g_transferIsNetwork = true;
+        g_isTransferringFile = true;
+        g_transferBytesDone = 0;
+        g_transferBytesTotal = totalFileBytes(files);
+
+        std::vector<FileEntry> zipEntries;
+        u32 zipSize = 0;
+        std::string zipName = StringUtils::format("/3ds/Checkpoint/transfer_send_%s.zip", DateTime::dateTimeStr().c_str());
+        std::u16string zipPath = StringUtils::UTF8toUTF16(zipName.c_str());
+
+        if (io::directoryExists(Archive::sdmc(), zipPath)) {
+            io::deleteFolderRecursively(Archive::sdmc(), zipPath);
+        }
+        if (io::fileExists(Archive::sdmc(), zipPath)) {
+            FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, zipPath.data()));
+        }
+        std::string zipError;
+        if (!writeZip(backupPath, zipPath, zipEntries, zipSize, zipError)) {
+            clearTransferState();
+            outError = zipError.empty() ? "Failed to create backup package." : zipError;
+            return false;
+        }
+        payloadPath = zipPath;
+        payloadName = "backup.zip";
+        payloadSize = zipSize;
+    }
+    else {
+        const FileEntry& entry = files.front();
+        payloadPath = entry.absPath;
+        payloadName = entry.relPath;
+        payloadSize = entry.size;
     }
 
-    const FileEntry& entry = files.front();
-
-    g_transferBytesTotal = entry.size;
+    g_transferBytesTotal = payloadSize;
     g_transferBytesDone = 0;
-    g_transferMode = "Enviando";
+    g_transferMode = "Sending backup";
     g_transferIsNetwork = true;
     g_isTransferringFile = true;
 
@@ -706,8 +830,9 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     meta["titleName"] = title.shortDescription();
     meta["dataType"] = dataType;
     meta["backupName"] = backupName;
-    meta["fileBytesTotal"] = entry.size;
-    meta["fileName"] = entry.relPath;
+    meta["isZip"] = isZip;
+    meta["fileBytesTotal"] = payloadSize;
+    meta["fileName"] = payloadName;
     meta["timestamp"] = DateTime::logDateTime();
 
     std::string metaStr = meta.dump();
@@ -718,7 +843,7 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         "Content-Type: application/json\r\n\r\n" +
         metaStr + "\r\n";
 
-    std::string fileName = entry.relPath;
+    std::string fileName = payloadName;
     size_t slashPos = fileName.find_last_of('/');
     if (slashPos != std::string::npos) {
         fileName = fileName.substr(slashPos + 1);
@@ -732,12 +857,14 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
 
     std::string partEnd = "\r\n--" + boundary + "--\r\n";
 
-    u32 contentLength = partMeta.size() + partFileHeader.size() + entry.size + partEnd.size();
+    u32 contentLength = partMeta.size() + partFileHeader.size() + payloadSize + partEnd.size();
 
     int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (sock < 0) {
-        g_isTransferringFile = false;
-        g_transferIsNetwork = false;
+        if (isZip) {
+            FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, payloadPath.data()));
+        }
+        clearTransferState();
         outError = "Failed to open socket.";
         return false;
     }
@@ -749,8 +876,10 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     addr.sin_addr.s_addr = inet_addr(ip.c_str());
     if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
         close(sock);
-        g_isTransferringFile = false;
-        g_transferIsNetwork = false;
+        if (isZip) {
+            FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, payloadPath.data()));
+        }
+        clearTransferState();
         outError = "Failed to connect.";
         return false;
     }
@@ -764,7 +893,7 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         partFileHeader.size());
 
     if (ok) {
-        FSStream input(Archive::sdmc(), entry.absPath, FS_OPEN_READ);
+        FSStream input(Archive::sdmc(), payloadPath, FS_OPEN_READ);
         if (!input.good()) {
             ok = false;
         }
@@ -781,12 +910,7 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
                     break;
                 }
                 g_transferBytesDone += rd;
-
-                C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
-                g_screen->drawTop();
-                C2D_SceneBegin(g_bottom);
-                g_screen->drawBottom();
-                Gui::frameEnd();
+                renderTransferFrame();
             }
             input.close();
         }
@@ -801,8 +925,11 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
 
     close(sock);
 
-    g_isTransferringFile = false;
-    g_transferIsNetwork = false;
+    if (isZip) {
+        FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, payloadPath.data()));
+    }
+
+    clearTransferState();
 
     if (!ok) {
         outError = "Transfer failed.";

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -518,17 +518,6 @@ namespace {
             backupName = "Received_" + DateTime::dateTimeStr();
         }
 
-        std::u16string tempZipPath = StringUtils::UTF8toUTF16(TEMP_ZIP_RECV);
-        FSStream output(Archive::sdmc(), tempZipPath, FS_OPEN_WRITE, (u32)fileData.size());
-        if (!output.good()) {
-            cleanup();
-            return {500, "application/json", "{\"ok\":false,\"error\":\"Failed to store ZIP\"}"};
-        }
-        if (!fileData.empty()) {
-            output.write(fileData.data(), (u32)fileData.size());
-        }
-        output.close();
-
         std::u16string basePath = StringUtils::UTF8toUTF16(dataType == "extdata" ? "/3ds/Checkpoint/extdata/" : "/3ds/Checkpoint/saves/");
 
         std::u16string destRoot;
@@ -570,15 +559,30 @@ namespace {
         }
         io::createDirectory(Archive::sdmc(), backupRoot);
 
-        std::string extractError;
-        bool ok = extractZip(tempZipPath, backupRoot, extractError);
-        FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, tempZipPath.data()));
+        std::string fileName = meta.value("fileName", "");
+        if (fileName.empty()) {
+            fileName = "received.bin";
+        }
+        std::u16string safeFileName = StringUtils::removeForbiddenCharacters(StringUtils::UTF8toUTF16(fileName.c_str()));
+        std::string safeFileNameUtf8 = StringUtils::UTF16toUTF8(safeFileName);
+        if (safeFileNameUtf8.empty()) {
+            safeFileNameUtf8 = "received.bin";
+            safeFileName = StringUtils::UTF8toUTF16("received.bin");
+        }
+        ensureDirectoryPath(backupRoot, safeFileNameUtf8);
+
+        std::u16string outputPath = backupRoot + safeFileName;
+        FSStream output(Archive::sdmc(), outputPath, FS_OPEN_WRITE, (u32)fileData.size());
+        if (!output.good()) {
+            cleanup();
+            return {500, "application/json", "{\"ok\":false,\"error\":\"Failed to store file\"}"};
+        }
+        if (!fileData.empty()) {
+            output.write(fileData.data(), (u32)fileData.size());
+        }
+        output.close();
 
         cleanup();
-
-        if (!ok) {
-            return {500, "application/json", "{\"ok\":false,\"error\":\"Extract failed\"}"};
-        }
 
         if (foundTitle) {
             TitleLoader::refreshDirectories(tid);
@@ -679,15 +683,19 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     const std::string& ip, u16 port, const std::string& token, std::string& outError)
 {
     std::vector<FileEntry> files;
-    u32 zipSize = 0;
-    std::u16string zipPath = StringUtils::UTF8toUTF16(TEMP_ZIP_SEND);
-
-    if (!writeZip(backupPath, zipPath, files, zipSize)) {
-        outError = "Failed to create ZIP.";
+    collectFiles(Archive::sdmc(), backupPath, StringUtils::UTF8toUTF16(""), files);
+    if (files.empty()) {
+        outError = "No files to send.";
+        return false;
+    }
+    if (files.size() != 1) {
+        outError = "Multiple files found. ZIP transfer required.";
         return false;
     }
 
-    g_transferBytesTotal = zipSize;
+    const FileEntry& entry = files.front();
+
+    g_transferBytesTotal = entry.size;
     g_transferBytesDone = 0;
     g_transferMode = "Enviando";
     g_transferIsNetwork = true;
@@ -698,7 +706,8 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     meta["titleName"] = title.shortDescription();
     meta["dataType"] = dataType;
     meta["backupName"] = backupName;
-    meta["zipBytesTotal"] = zipSize;
+    meta["fileBytesTotal"] = entry.size;
+    meta["fileName"] = entry.relPath;
     meta["timestamp"] = DateTime::logDateTime();
 
     std::string metaStr = meta.dump();
@@ -709,13 +718,21 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         "Content-Type: application/json\r\n\r\n" +
         metaStr + "\r\n";
 
+    std::string fileName = entry.relPath;
+    size_t slashPos = fileName.find_last_of('/');
+    if (slashPos != std::string::npos) {
+        fileName = fileName.substr(slashPos + 1);
+    }
+    if (fileName.empty()) {
+        fileName = "backup.bin";
+    }
     std::string partFileHeader = "--" + boundary + "\r\n"
-        "Content-Disposition: form-data; name=\"file\"; filename=\"backup.zip\"\r\n"
-        "Content-Type: application/zip\r\n\r\n";
+        "Content-Disposition: form-data; name=\"file\"; filename=\"" + fileName + "\"\r\n"
+        "Content-Type: application/octet-stream\r\n\r\n";
 
     std::string partEnd = "\r\n--" + boundary + "--\r\n";
 
-    u32 contentLength = partMeta.size() + partFileHeader.size() + zipSize + partEnd.size();
+    u32 contentLength = partMeta.size() + partFileHeader.size() + entry.size + partEnd.size();
 
     int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if (sock < 0) {
@@ -747,7 +764,7 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         partFileHeader.size());
 
     if (ok) {
-        FSStream input(Archive::sdmc(), zipPath, FS_OPEN_READ);
+        FSStream input(Archive::sdmc(), entry.absPath, FS_OPEN_READ);
         if (!input.good()) {
             ok = false;
         }
@@ -783,8 +800,6 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     recv(sock, responseBuf, sizeof(responseBuf) - 1, 0);
 
     close(sock);
-
-    FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, zipPath.data()));
 
     g_isTransferringFile = false;
     g_transferIsNetwork = false;

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -38,6 +38,7 @@
 #include "json.hpp"
 #include <3ds.h>
 #include <arpa/inet.h>
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
 #include <map>
@@ -49,13 +50,16 @@
 
 namespace {
     static const int TRANSFER_PORT = 8000;
-    static const char* TEMP_ZIP_RECV = "sdmc:/3ds/Checkpoint/transfer_recv.zip";
+    static const char* TEMP_ZIP_RECV = "/3ds/Checkpoint/transfer_recv.zip";
 
     std::string g_token;
     std::string g_receiverIp;
     int g_receiverPort = TRANSFER_PORT;
     bool g_receiverRunning = false;
+    std::atomic<bool> g_pendingRefresh{false};
+    std::atomic<bool> g_receiverCompleted{false};
     std::string g_receiverNotice;
+    std::string g_receiverCompletedName;
 
     struct FileEntry {
         std::u16string absPath;
@@ -69,6 +73,7 @@ namespace {
         u32 crc;
         u32 size;
         u32 offset;
+        bool isDirectory;
     };
 
     u32 crcTable[256];
@@ -128,7 +133,8 @@ namespace {
         return crc ^ 0xFFFFFFFFu;
     }
 
-    void collectFiles(FS_Archive arch, const std::u16string& root, const std::u16string& sub, std::vector<FileEntry>& out)
+    void collectFiles(
+        FS_Archive arch, const std::u16string& root, const std::u16string& sub, std::vector<FileEntry>& out, std::vector<std::string>* outDirs = nullptr)
     {
         std::u16string current = root + sub;
         if (current.empty() || current.back() != u'/') {
@@ -140,9 +146,15 @@ namespace {
         }
         for (size_t i = 0, sz = items.size(); i < sz; i++) {
             std::u16string name = items.entry(i);
+            if (name == u"." || name == u"..") {
+                continue;
+            }
             if (items.folder(i)) {
                 std::u16string nextSub = sub + name + StringUtils::UTF8toUTF16("/");
-                collectFiles(arch, root, nextSub, out);
+                if (outDirs != nullptr) {
+                    outDirs->push_back(StringUtils::UTF16toUTF8(nextSub));
+                }
+                collectFiles(arch, root, nextSub, out, outDirs);
             }
             else {
                 std::u16string abs = current + name;
@@ -185,9 +197,10 @@ namespace {
     bool writeZip(const std::u16string& root, const std::u16string& zipPath, std::vector<FileEntry>& files, u32& outZipSize, std::string& outError)
     {
         files.clear();
-        collectFiles(Archive::sdmc(), root, StringUtils::UTF8toUTF16(""), files);
-        if (files.empty()) {
-            outError = "No files found to package.";
+        std::vector<std::string> dirs;
+        collectFiles(Archive::sdmc(), root, StringUtils::UTF8toUTF16(""), files, &dirs);
+        if (files.empty() && dirs.empty()) {
+            outError = "No files or folders found to package.";
             return false;
         }
 
@@ -196,6 +209,10 @@ namespace {
         }
 
         u32 total = 22; // end of central directory
+        for (const auto& dir : dirs) {
+            total += 30 + dir.size(); // local header
+            total += 46 + dir.size(); // central directory
+        }
         for (const auto& entry : files) {
             total += 30 + entry.relPath.size() + entry.size; // local header + data
             total += 46 + entry.relPath.size();              // central directory
@@ -209,10 +226,34 @@ namespace {
         }
 
         std::vector<ZipEntry> central;
-        central.reserve(files.size());
+        central.reserve(dirs.size() + files.size());
 
         static const u32 kBuf = 0x4000;
         std::unique_ptr<u8[]> buf(new u8[kBuf]);
+
+        for (const auto& dir : dirs) {
+            ZipEntry centralEntry;
+            centralEntry.name = dir;
+            centralEntry.crc = 0;
+            centralEntry.size = 0;
+            centralEntry.offset = output.offset();
+            centralEntry.isDirectory = true;
+
+            writeLe32(output, 0x04034b50);
+            writeLe16(output, 20);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe32(output, 0);
+            writeLe32(output, 0);
+            writeLe32(output, 0);
+            writeLe16(output, (u16)dir.size());
+            writeLe16(output, 0);
+            output.write(dir.data(), dir.size());
+
+            central.push_back(centralEntry);
+        }
 
         for (const auto& entry : files) {
             ZipEntry centralEntry;
@@ -220,6 +261,7 @@ namespace {
             centralEntry.crc = entry.crc;
             centralEntry.size = entry.size;
             centralEntry.offset = output.offset();
+            centralEntry.isDirectory = false;
 
             writeLe32(output, 0x04034b50);
             writeLe16(output, 20);
@@ -271,7 +313,7 @@ namespace {
             writeLe16(output, 0);
             writeLe16(output, 0);
             writeLe16(output, 0);
-            writeLe32(output, 0);
+            writeLe32(output, entry.isDirectory ? (((u32)FS_ATTRIBUTE_DIRECTORY) << 16) : 0);
             writeLe32(output, entry.offset);
             output.write(entry.name.data(), entry.name.size());
         }
@@ -390,11 +432,19 @@ namespace {
             std::string name;
             name.resize(nameLen);
             if (nameLen > 0) {
-                input.read(name.data(), nameLen);
+                if (input.read(name.data(), nameLen) != nameLen) {
+                    outError = "Corrupted ZIP header.";
+                    input.close();
+                    return false;
+                }
             }
             if (extraLen > 0) {
                 std::unique_ptr<u8[]> extra(new u8[extraLen]);
-                input.read(extra.get(), extraLen);
+                if (input.read(extra.get(), extraLen) != extraLen) {
+                    outError = "Corrupted ZIP header.";
+                    input.close();
+                    return false;
+                }
             }
 
             if (compression != 0 || (flags & 0x08)) {
@@ -434,12 +484,21 @@ namespace {
                 u32 chunk = remaining > kBuf ? kBuf : remaining;
                 u32 rd = input.read(buf.get(), chunk);
                 if (rd == 0) {
-                    break;
+                    outError = "Corrupted ZIP payload.";
+                    output.close();
+                    input.close();
+                    return false;
                 }
                 output.write(buf.get(), rd);
                 remaining -= rd;
 
                 g_transferBytesDone += rd;
+            }
+            if (remaining != 0) {
+                outError = "Corrupted ZIP payload.";
+                output.close();
+                input.close();
+                return false;
             }
             output.close();
         }
@@ -575,6 +634,7 @@ namespace {
         std::string titleName = meta.value("titleName", "Unknown");
         std::string backupName = meta.value("backupName", "");
         bool isZip = meta.value("isZip", false);
+        g_receiverNotice.clear();
         if (backupName.empty()) {
             backupName = "Received_" + DateTime::dateTimeStr();
         }
@@ -583,6 +643,7 @@ namespace {
 
         std::u16string destRoot;
         bool foundTitle = false;
+        bool mappedByName = false;
         u64 tid = 0;
         if (!titleId.empty()) {
             tid = strtoull(titleId.c_str(), nullptr, 16);
@@ -592,6 +653,16 @@ namespace {
             if (TitleLoader::getTitleById(t, tid)) {
                 destRoot = (dataType == "extdata") ? t.extdataPath() : t.savePath();
                 foundTitle = true;
+            }
+        }
+        if (!foundTitle && !titleName.empty()) {
+            Title t;
+            if (TitleLoader::getTitleByName(t, titleName)) {
+                destRoot = (dataType == "extdata") ? t.extdataPath() : t.savePath();
+                foundTitle = true;
+                mappedByName = true;
+                g_receiverNotice = "Warning: title ID mismatch. Backup mapped by title name.";
+                Logging::warning("Title ID {} not found, mapped by title name '{}'.", titleId, titleName);
             }
         }
 
@@ -605,7 +676,7 @@ namespace {
             if (!io::directoryExists(Archive::sdmc(), destRoot)) {
                 io::createDirectory(Archive::sdmc(), destRoot);
             }
-            g_receiverNotice = "Warning: unknown title. Backup stored in a generic folder.";
+            g_receiverNotice = "Warning: unknown title. Stored in:\n" + StringUtils::UTF16toUTF8(destRoot);
             Logging::warning("Received backup for unknown title {} (stored under {}).", titleId, StringUtils::UTF16toUTF8(destRoot));
         }
 
@@ -641,7 +712,8 @@ namespace {
         FSStream output(Archive::sdmc(), outputPath, FS_OPEN_WRITE, (u32)fileData.size());
         if (!output.good()) {
             cleanup();
-            return {500, "application/json", "{\"ok\":false,\"error\":\"Failed to store file\"}"};
+            std::string message = StringUtils::format("Failed to store file (0x%08lX).", output.result());
+            return {500, "application/json", "{\"ok\":false,\"error\":\"" + message + "\"}"};
         }
         if (!fileData.empty()) {
             output.write(fileData.data(), (u32)fileData.size());
@@ -669,9 +741,12 @@ namespace {
 
         cleanup();
 
-        if (foundTitle) {
-            TitleLoader::refreshDirectories(tid);
+        if (!mappedByName && foundTitle) {
+            g_receiverNotice.clear();
         }
+        g_receiverCompletedName = backupName;
+        g_receiverCompleted.store(true);
+        g_pendingRefresh.store(true);
 
         nlohmann::json resp;
         resp["ok"] = true;
@@ -707,6 +782,8 @@ bool Transfer::startReceiver(std::string& outError)
         g_token = StringUtils::format("%04d", pin);
         g_receiverIp = Server::getAddress();
         g_receiverNotice.clear();
+        g_receiverCompletedName.clear();
+        g_receiverCompleted.store(false);
         size_t pos = g_receiverIp.find("://");
         if (pos != std::string::npos) {
             g_receiverIp = g_receiverIp.substr(pos + 3);
@@ -739,6 +816,11 @@ bool Transfer::receiverRunning(void)
     return g_receiverRunning;
 }
 
+bool Transfer::consumePendingRefresh(void)
+{
+    return g_pendingRefresh.exchange(false);
+}
+
 std::string Transfer::receiverToken(void)
 {
     return g_token;
@@ -759,22 +841,39 @@ std::string Transfer::receiverNotice(void)
     return g_receiverNotice;
 }
 
+bool Transfer::receiverHasCompleted(void)
+{
+    return g_receiverCompleted.load();
+}
+
+std::string Transfer::receiverCompletedName(void)
+{
+    return g_receiverCompletedName;
+}
+
 void Transfer::clearReceiverNotice(void)
 {
     g_receiverNotice.clear();
+}
+
+void Transfer::clearReceiverCompletion(void)
+{
+    g_receiverCompletedName.clear();
+    g_receiverCompleted.store(false);
 }
 
 bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, const std::string& backupName, const std::string& dataType,
     const std::string& ip, u16 port, const std::string& token, std::string& outError)
 {
     std::vector<FileEntry> files;
-    collectFiles(Archive::sdmc(), backupPath, StringUtils::UTF8toUTF16(""), files);
-    if (files.empty()) {
-        outError = "No files to send.";
+    std::vector<std::string> dirs;
+    collectFiles(Archive::sdmc(), backupPath, StringUtils::UTF8toUTF16(""), files, &dirs);
+    if (files.empty() && dirs.empty()) {
+        outError = "Selected backup is empty.";
         return false;
     }
 
-    bool isZip = files.size() > 1;
+    bool isZip = files.size() != 1 || !dirs.empty();
     std::u16string payloadPath;
     std::string payloadName;
     u32 payloadSize = 0;
@@ -836,7 +935,7 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     meta["timestamp"] = DateTime::logDateTime();
 
     std::string metaStr = meta.dump();
-    std::string boundary = "----checkpoint-boundary";
+    std::string boundary = StringUtils::format("----checkpoint-boundary-%llu", (unsigned long long)osGetTime());
 
     std::string partMeta = "--" + boundary + "\r\n"
         "Content-Disposition: form-data; name=\"meta\"\r\n"
@@ -920,8 +1019,17 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         ok = sendAll(sock, partEnd.data(), partEnd.size());
     }
 
-    char responseBuf[256];
-    recv(sock, responseBuf, sizeof(responseBuf) - 1, 0);
+    std::string response;
+    {
+        char responseBuf[512];
+        while (true) {
+            int rc = recv(sock, responseBuf, sizeof(responseBuf), 0);
+            if (rc <= 0) {
+                break;
+            }
+            response.append(responseBuf, (size_t)rc);
+        }
+    }
 
     close(sock);
 
@@ -933,6 +1041,33 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
 
     if (!ok) {
         outError = "Transfer failed.";
+        return false;
+    }
+
+    bool httpOk = response.rfind("HTTP/1.1 200", 0) == 0 || response.rfind("HTTP/1.0 200", 0) == 0;
+    if (!httpOk) {
+        if (response.empty()) {
+            outError = "Receiver returned no response.";
+        }
+        else {
+            std::string receiverError;
+            size_t bodyPos = response.find("\r\n\r\n");
+            if (bodyPos != std::string::npos && bodyPos + 4 < response.size()) {
+                std::string body = response.substr(bodyPos + 4);
+                auto j = nlohmann::json::parse(body, nullptr, false);
+                if (!j.is_discarded() && j.contains("error") && j["error"].is_string()) {
+                    receiverError = j["error"].get<std::string>();
+                }
+            }
+            size_t lineEnd = response.find("\r\n");
+            std::string statusLine = lineEnd == std::string::npos ? response : response.substr(0, lineEnd);
+            if (!receiverError.empty()) {
+                outError = "Receiver error: " + receiverError;
+            }
+            else {
+                outError = "Receiver rejected upload: " + statusLine;
+            }
+        }
         return false;
     }
 

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -49,8 +49,8 @@
 
 namespace {
     static const int TRANSFER_PORT = 8000;
-    static const char* TEMP_ZIP_SEND = "sdmc:/3ds/Checkpoint/transfer_send.zip";
-    static const char* TEMP_ZIP_RECV = "sdmc:/3ds/Checkpoint/transfer_recv.zip";
+    [[maybe_unused]] static const char* TEMP_ZIP_SEND = "sdmc:/3ds/Checkpoint/transfer_send.zip";
+    [[maybe_unused]] static const char* TEMP_ZIP_RECV = "sdmc:/3ds/Checkpoint/transfer_recv.zip";
 
     std::string g_token;
     std::string g_receiverIp;
@@ -165,7 +165,7 @@ namespace {
         out.write(b, 4);
     }
 
-    bool writeZip(const std::u16string& root, const std::u16string& zipPath, std::vector<FileEntry>& files, u32& outZipSize)
+    [[maybe_unused]] bool writeZip(const std::u16string& root, const std::u16string& zipPath, std::vector<FileEntry>& files, u32& outZipSize)
     {
         files.clear();
         collectFiles(Archive::sdmc(), root, StringUtils::UTF8toUTF16(""), files);
@@ -308,7 +308,7 @@ namespace {
         return true;
     }
 
-    bool extractZip(const std::u16string& zipPath, const std::u16string& destRoot, std::string& outError)
+    [[maybe_unused]] bool extractZip(const std::u16string& zipPath, const std::u16string& destRoot, std::string& outError)
     {
         FSStream input(Archive::sdmc(), zipPath, FS_OPEN_READ);
         if (!input.good()) {

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -1,0 +1,798 @@
+/*
+ *   This file is part of Checkpoint
+ *   Copyright (C) 2017-2026 Bernardo Giordano, FlagBrew
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Additional Terms 7.b and 7.c of GPLv3 apply to this file:
+ *       * Requiring preservation of specified reasonable legal notices or
+ *         author attributions in that material or in the Appropriate Legal
+ *         Notices displayed by works containing it.
+ *       * Prohibiting misrepresentation of the origin of that material,
+ *         or requiring that modified versions of such material be marked in
+ *         reasonable ways as different from the original version.
+ */
+
+#include "transfer.hpp"
+#include "common.hpp"
+#include "directory.hpp"
+#include "fsstream.hpp"
+#include "gui.hpp"
+#include "io.hpp"
+#include "loader.hpp"
+#include "logging.hpp"
+#include "main.hpp"
+#include "server.hpp"
+#include "util.hpp"
+#include "json.hpp"
+#include <3ds.h>
+#include <arpa/inet.h>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <vector>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace {
+    static const int TRANSFER_PORT = 8000;
+    static const char* TEMP_ZIP_SEND = "sdmc:/3ds/Checkpoint/transfer_send.zip";
+    static const char* TEMP_ZIP_RECV = "sdmc:/3ds/Checkpoint/transfer_recv.zip";
+
+    std::string g_token;
+    std::string g_receiverIp;
+    int g_receiverPort = TRANSFER_PORT;
+    bool g_receiverRunning = false;
+    std::string g_receiverNotice;
+
+    struct FileEntry {
+        std::u16string absPath;
+        std::string relPath;
+        u32 size;
+        u32 crc;
+    };
+
+    struct ZipEntry {
+        std::string name;
+        u32 crc;
+        u32 size;
+        u32 offset;
+    };
+
+    u32 crcTable[256];
+    bool crcInit = false;
+
+    void initCrc(void)
+    {
+        if (crcInit) {
+            return;
+        }
+        for (u32 i = 0; i < 256; ++i) {
+            u32 c = i;
+            for (int j = 0; j < 8; ++j) {
+                c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            }
+            crcTable[i] = c;
+        }
+        crcInit = true;
+    }
+
+    u32 updateCrc(u32 crc, const u8* data, size_t len)
+    {
+        u32 c = crc;
+        for (size_t i = 0; i < len; ++i) {
+            c = crcTable[(c ^ data[i]) & 0xFFu] ^ (c >> 8);
+        }
+        return c;
+    }
+
+    u32 computeCrc(FS_Archive arch, const std::u16string& path)
+    {
+        FSStream input(arch, path, FS_OPEN_READ);
+        if (!input.good()) {
+            return 0;
+        }
+        initCrc();
+        u32 crc = 0xFFFFFFFFu;
+        static const u32 kBuf = 0x4000;
+        std::unique_ptr<u8[]> buf(new u8[kBuf]);
+        while (!input.eof()) {
+            u32 rd = input.read(buf.get(), kBuf);
+            if (rd == 0) {
+                break;
+            }
+            crc = updateCrc(crc, buf.get(), rd);
+        }
+        input.close();
+        return crc ^ 0xFFFFFFFFu;
+    }
+
+    void collectFiles(FS_Archive arch, const std::u16string& root, const std::u16string& sub, std::vector<FileEntry>& out)
+    {
+        std::u16string current = root + sub;
+        if (current.empty() || current.back() != u'/') {
+            current += StringUtils::UTF8toUTF16("/");
+        }
+        Directory items(arch, current);
+        if (!items.good()) {
+            return;
+        }
+        for (size_t i = 0, sz = items.size(); i < sz; i++) {
+            std::u16string name = items.entry(i);
+            if (items.folder(i)) {
+                std::u16string nextSub = sub + name + StringUtils::UTF8toUTF16("/");
+                collectFiles(arch, root, nextSub, out);
+            }
+            else {
+                std::u16string abs = current + name;
+                std::string rel = StringUtils::UTF16toUTF8(sub + name);
+                FSStream input(arch, abs, FS_OPEN_READ);
+                if (!input.good()) {
+                    continue;
+                }
+                FileEntry entry;
+                entry.absPath = abs;
+                entry.relPath = rel;
+                entry.size = input.size();
+                input.close();
+                out.push_back(entry);
+            }
+        }
+    }
+
+    void writeLe16(FSStream& out, u16 v)
+    {
+        u8 b[2] = { (u8)(v & 0xFF), (u8)((v >> 8) & 0xFF) };
+        out.write(b, 2);
+    }
+
+    void writeLe32(FSStream& out, u32 v)
+    {
+        u8 b[4] = { (u8)(v & 0xFF), (u8)((v >> 8) & 0xFF), (u8)((v >> 16) & 0xFF), (u8)((v >> 24) & 0xFF) };
+        out.write(b, 4);
+    }
+
+    bool writeZip(const std::u16string& root, const std::u16string& zipPath, std::vector<FileEntry>& files, u32& outZipSize)
+    {
+        files.clear();
+        collectFiles(Archive::sdmc(), root, StringUtils::UTF8toUTF16(""), files);
+        if (files.empty()) {
+            return false;
+        }
+
+        for (auto& entry : files) {
+            entry.crc = computeCrc(Archive::sdmc(), entry.absPath);
+        }
+
+        u32 total = 22; // end of central directory
+        for (const auto& entry : files) {
+            total += 30 + entry.relPath.size() + entry.size; // local header + data
+            total += 46 + entry.relPath.size();              // central directory
+        }
+        outZipSize = total;
+
+        FSStream output(Archive::sdmc(), zipPath, FS_OPEN_WRITE, total);
+        if (!output.good()) {
+            return false;
+        }
+
+        std::vector<ZipEntry> central;
+        central.reserve(files.size());
+
+        static const u32 kBuf = 0x4000;
+        std::unique_ptr<u8[]> buf(new u8[kBuf]);
+
+        for (const auto& entry : files) {
+            ZipEntry centralEntry;
+            centralEntry.name = entry.relPath;
+            centralEntry.crc = entry.crc;
+            centralEntry.size = entry.size;
+            centralEntry.offset = output.offset();
+
+            writeLe32(output, 0x04034b50);
+            writeLe16(output, 20);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe32(output, entry.crc);
+            writeLe32(output, entry.size);
+            writeLe32(output, entry.size);
+            writeLe16(output, (u16)entry.relPath.size());
+            writeLe16(output, 0);
+            output.write(entry.relPath.data(), entry.relPath.size());
+
+            FSStream input(Archive::sdmc(), entry.absPath, FS_OPEN_READ);
+            if (!input.good()) {
+                output.close();
+                return false;
+            }
+            while (!input.eof()) {
+                u32 rd = input.read(buf.get(), kBuf);
+                if (rd == 0) {
+                    break;
+                }
+                output.write(buf.get(), rd);
+            }
+            input.close();
+
+            central.push_back(centralEntry);
+        }
+
+        u32 centralOffset = output.offset();
+        for (const auto& entry : central) {
+            writeLe32(output, 0x02014b50);
+            writeLe16(output, 20);
+            writeLe16(output, 20);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe32(output, entry.crc);
+            writeLe32(output, entry.size);
+            writeLe32(output, entry.size);
+            writeLe16(output, (u16)entry.name.size());
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe16(output, 0);
+            writeLe32(output, 0);
+            writeLe32(output, entry.offset);
+            output.write(entry.name.data(), entry.name.size());
+        }
+
+        u32 centralSize = output.offset() - centralOffset;
+        writeLe32(output, 0x06054b50);
+        writeLe16(output, 0);
+        writeLe16(output, 0);
+        writeLe16(output, (u16)central.size());
+        writeLe16(output, (u16)central.size());
+        writeLe32(output, centralSize);
+        writeLe32(output, centralOffset);
+        writeLe16(output, 0);
+
+        output.close();
+        return true;
+    }
+
+    u16 readLe16(FSStream& input)
+    {
+        u8 b[2];
+        if (input.read(b, 2) != 2) {
+            return 0;
+        }
+        return (u16)(b[0] | (b[1] << 8));
+    }
+
+    u32 readLe32(FSStream& input)
+    {
+        u8 b[4];
+        if (input.read(b, 4) != 4) {
+            return 0;
+        }
+        return (u32)(b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24));
+    }
+
+    bool ensureDirectoryPath(const std::u16string& base, const std::string& relPath)
+    {
+        std::u16string current = base;
+        size_t start = 0;
+        while (true) {
+            size_t pos = relPath.find('/', start);
+            if (pos == std::string::npos) {
+                break;
+            }
+            std::string part = relPath.substr(start, pos - start);
+            if (!part.empty()) {
+                current += StringUtils::UTF8toUTF16(part.c_str());
+                if (!io::directoryExists(Archive::sdmc(), current)) {
+                    io::createDirectory(Archive::sdmc(), current);
+                }
+                current += StringUtils::UTF8toUTF16("/");
+            }
+            start = pos + 1;
+        }
+        return true;
+    }
+
+    bool extractZip(const std::u16string& zipPath, const std::u16string& destRoot, std::string& outError)
+    {
+        FSStream input(Archive::sdmc(), zipPath, FS_OPEN_READ);
+        if (!input.good()) {
+            outError = "Failed to open received ZIP.";
+            return false;
+        }
+
+        while (!input.eof()) {
+            u32 sig = readLe32(input);
+            if (sig != 0x04034b50) {
+                break;
+            }
+            u16 version = readLe16(input);
+            (void)version;
+            u16 flags = readLe16(input);
+            u16 compression = readLe16(input);
+            readLe16(input);
+            readLe16(input);
+            u32 crc = readLe32(input);
+            u32 compSize = readLe32(input);
+            u32 uncompSize = readLe32(input);
+            u16 nameLen = readLe16(input);
+            u16 extraLen = readLe16(input);
+
+            std::string name;
+            name.resize(nameLen);
+            if (nameLen > 0) {
+                input.read(name.data(), nameLen);
+            }
+            if (extraLen > 0) {
+                std::unique_ptr<u8[]> extra(new u8[extraLen]);
+                input.read(extra.get(), extraLen);
+            }
+
+            if (compression != 0 || (flags & 0x08)) {
+                outError = "Unsupported ZIP compression.";
+                input.close();
+                return false;
+            }
+            (void)crc;
+
+            if (!name.empty() && name.back() == '/') {
+                std::u16string dirPath = destRoot + StringUtils::UTF8toUTF16(name.c_str());
+                if (!io::directoryExists(Archive::sdmc(), dirPath)) {
+                    io::createDirectory(Archive::sdmc(), dirPath);
+                }
+                continue;
+            }
+
+            ensureDirectoryPath(destRoot, name);
+            std::u16string outPath = destRoot + StringUtils::UTF8toUTF16(name.c_str());
+            FSStream output(Archive::sdmc(), outPath, FS_OPEN_WRITE, uncompSize);
+            if (!output.good()) {
+                outError = "Failed to write extracted file.";
+                input.close();
+                return false;
+            }
+
+            static const u32 kBuf = 0x4000;
+            std::unique_ptr<u8[]> buf(new u8[kBuf]);
+            u32 remaining = compSize;
+            while (remaining > 0) {
+                u32 chunk = remaining > kBuf ? kBuf : remaining;
+                u32 rd = input.read(buf.get(), chunk);
+                if (rd == 0) {
+                    break;
+                }
+                output.write(buf.get(), rd);
+                remaining -= rd;
+
+                g_transferBytesDone += rd;
+            }
+            output.close();
+        }
+
+        input.close();
+        return true;
+    }
+
+    std::string headerValue(const std::string& headers, const std::string& key)
+    {
+        std::string needle = key + ":";
+        size_t pos = headers.find(needle);
+        if (pos == std::string::npos) {
+            return "";
+        }
+        pos += needle.size();
+        while (pos < headers.size() && (headers[pos] == ' ' || headers[pos] == '\t')) {
+            pos++;
+        }
+        size_t end = headers.find("\r\n", pos);
+        if (end == std::string::npos) {
+            end = headers.size();
+        }
+        return headers.substr(pos, end - pos);
+    }
+
+    bool parseMultipart(const std::string& request, std::string& outMeta, std::string& outFile, std::string& outError)
+    {
+        size_t headerEnd = request.find("\r\n\r\n");
+        if (headerEnd == std::string::npos) {
+            outError = "Bad request.";
+            return false;
+        }
+        std::string headers = request.substr(0, headerEnd);
+        std::string body = request.substr(headerEnd + 4);
+
+        std::string contentType = headerValue(headers, "Content-Type");
+        size_t bpos = contentType.find("boundary=");
+        if (bpos == std::string::npos) {
+            outError = "Missing boundary.";
+            return false;
+        }
+        std::string boundary = contentType.substr(bpos + 9);
+        if (!boundary.empty() && boundary.front() == '"' && boundary.back() == '"') {
+            boundary = boundary.substr(1, boundary.size() - 2);
+        }
+
+        std::string boundaryMarker = "--" + boundary;
+        size_t pos = body.find(boundaryMarker);
+        while (pos != std::string::npos) {
+            pos += boundaryMarker.size();
+            if (pos + 2 <= body.size() && body.compare(pos, 2, "--") == 0) {
+                break;
+            }
+            if (pos + 2 <= body.size() && body.compare(pos, 2, "\r\n") == 0) {
+                pos += 2;
+            }
+
+            size_t partHeaderEnd = body.find("\r\n\r\n", pos);
+            if (partHeaderEnd == std::string::npos) {
+                break;
+            }
+            std::string partHeader = body.substr(pos, partHeaderEnd - pos);
+            size_t dataStart = partHeaderEnd + 4;
+            size_t nextBoundary = body.find("\r\n" + boundaryMarker, dataStart);
+            if (nextBoundary == std::string::npos) {
+                break;
+            }
+            size_t dataEnd = nextBoundary;
+            if (dataEnd >= 2 && body.compare(dataEnd - 2, 2, "\r\n") == 0) {
+                dataEnd -= 2;
+            }
+            std::string partData = body.substr(dataStart, dataEnd - dataStart);
+
+            if (partHeader.find("name=\"meta\"") != std::string::npos) {
+                outMeta = partData;
+            }
+            else if (partHeader.find("name=\"file\"") != std::string::npos) {
+                outFile = partData;
+            }
+
+            pos = nextBoundary + 2;
+        }
+
+        if (outMeta.empty() || outFile.empty()) {
+            outError = "Incomplete form data.";
+            return false;
+        }
+        return true;
+    }
+
+    Server::HttpResponse handleInfo(const std::string&, const std::string&)
+    {
+        nlohmann::json info;
+        info["device"] = "3DS";
+        info["version"] = StringUtils::format("%d.%d.%d", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
+        info["token"] = g_token;
+        info["maxUploadBytes"] = 0;
+        info["freeSpaceBytes"] = 0;
+        return {200, "application/json", info.dump()};
+    }
+
+    Server::HttpResponse handleUpload(const std::string&, const std::string& requestData)
+    {
+        auto cleanup = []() {
+            g_isTransferringFile = false;
+            g_transferIsNetwork  = false;
+        };
+        size_t headerEnd = requestData.find("\r\n\r\n");
+        std::string headers = headerEnd == std::string::npos ? requestData : requestData.substr(0, headerEnd);
+        std::string token = headerValue(headers, "X-CP-Token");
+        if (token != g_token) {
+            cleanup();
+            return {403, "application/json", "{\"ok\":false,\"error\":\"Invalid token\"}"};
+        }
+
+        std::string metaJson;
+        std::string fileData;
+        std::string error;
+        if (!parseMultipart(requestData, metaJson, fileData, error)) {
+            cleanup();
+            return {400, "application/json", "{\"ok\":false,\"error\":\"Bad upload\"}"};
+        }
+
+        auto meta = nlohmann::json::parse(metaJson, nullptr, false);
+        if (meta.is_discarded()) {
+            cleanup();
+            return {400, "application/json", "{\"ok\":false,\"error\":\"Invalid meta\"}"};
+        }
+
+        std::string dataType = meta.value("dataType", "save");
+        std::string titleId = meta.value("titleId", "");
+        std::string titleName = meta.value("titleName", "Unknown");
+        std::string backupName = meta.value("backupName", "");
+        if (backupName.empty()) {
+            backupName = "Received_" + DateTime::dateTimeStr();
+        }
+
+        std::u16string tempZipPath = StringUtils::UTF8toUTF16(TEMP_ZIP_RECV);
+        FSStream output(Archive::sdmc(), tempZipPath, FS_OPEN_WRITE, (u32)fileData.size());
+        if (!output.good()) {
+            cleanup();
+            return {500, "application/json", "{\"ok\":false,\"error\":\"Failed to store ZIP\"}"};
+        }
+        if (!fileData.empty()) {
+            output.write(fileData.data(), (u32)fileData.size());
+        }
+        output.close();
+
+        std::u16string basePath = StringUtils::UTF8toUTF16(dataType == "extdata" ? "/3ds/Checkpoint/extdata/" : "/3ds/Checkpoint/saves/");
+
+        std::u16string destRoot;
+        bool foundTitle = false;
+        u64 tid = 0;
+        if (!titleId.empty()) {
+            tid = strtoull(titleId.c_str(), nullptr, 16);
+        }
+        if (tid != 0) {
+            for (int i = 0; i < TitleLoader::getTitleCount(); i++) {
+                Title t;
+                TitleLoader::getTitle(t, i);
+                if (t.id() == tid) {
+                    destRoot = (dataType == "extdata") ? t.extdataPath() : t.savePath();
+                    foundTitle = true;
+                    break;
+                }
+            }
+        }
+
+        if (!foundTitle) {
+            std::string safeName = titleName.empty() ? "Unknown" : titleName;
+            std::string folder = safeName;
+            if (!titleId.empty()) {
+                folder = titleId + " " + safeName;
+            }
+            destRoot = basePath + StringUtils::removeForbiddenCharacters(StringUtils::UTF8toUTF16(folder.c_str()));
+            if (!io::directoryExists(Archive::sdmc(), destRoot)) {
+                io::createDirectory(Archive::sdmc(), destRoot);
+            }
+            g_receiverNotice = "Aviso: titulo desconocido. Backup guardado en carpeta generica.";
+            Logging::warning("Received backup for unknown title {} (stored under {}).", titleId, StringUtils::UTF16toUTF8(destRoot));
+        }
+
+        std::u16string backupRoot = destRoot + StringUtils::UTF8toUTF16("/") + StringUtils::removeForbiddenCharacters(StringUtils::UTF8toUTF16(backupName.c_str())) +
+            StringUtils::UTF8toUTF16("/");
+        if (io::directoryExists(Archive::sdmc(), backupRoot)) {
+            io::deleteFolderRecursively(Archive::sdmc(), backupRoot);
+        }
+        io::createDirectory(Archive::sdmc(), backupRoot);
+
+        std::string extractError;
+        bool ok = extractZip(tempZipPath, backupRoot, extractError);
+        FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, tempZipPath.data()));
+
+        cleanup();
+
+        if (!ok) {
+            return {500, "application/json", "{\"ok\":false,\"error\":\"Extract failed\"}"};
+        }
+
+        if (foundTitle) {
+            TitleLoader::refreshDirectories(tid);
+        }
+
+        nlohmann::json resp;
+        resp["ok"] = true;
+        resp["savedPath"] = StringUtils::UTF16toUTF8(backupRoot);
+        return {200, "application/json", resp.dump()};
+    }
+
+    bool sendAll(int sock, const void* data, size_t len)
+    {
+        const u8* ptr = static_cast<const u8*>(data);
+        size_t sent = 0;
+        while (sent < len) {
+            int rc = send(sock, ptr + sent, len - sent, 0);
+            if (rc <= 0) {
+                return false;
+            }
+            sent += rc;
+        }
+        return true;
+    }
+}
+
+bool Transfer::startReceiver(std::string& outError)
+{
+    if (!Server::isRunning()) {
+        outError = "HTTP server not available.";
+        return false;
+    }
+
+    if (!g_receiverRunning) {
+        srand((unsigned int)osGetTime());
+        int pin = 1000 + (rand() % 9000);
+        g_token = StringUtils::format("%04d", pin);
+        g_receiverIp = Server::getAddress();
+        g_receiverNotice.clear();
+        size_t pos = g_receiverIp.find("://");
+        if (pos != std::string::npos) {
+            g_receiverIp = g_receiverIp.substr(pos + 3);
+        }
+        pos = g_receiverIp.find(":");
+        if (pos != std::string::npos) {
+            g_receiverIp = g_receiverIp.substr(0, pos);
+        }
+        g_receiverPort = TRANSFER_PORT;
+
+        Server::registerHandler("/transfer/info", handleInfo);
+        Server::registerHandler("/transfer/upload", handleUpload);
+        g_receiverRunning = true;
+    }
+
+    return true;
+}
+
+void Transfer::stopReceiver(void)
+{
+    if (g_receiverRunning) {
+        Server::unregisterHandler("/transfer/info");
+        Server::unregisterHandler("/transfer/upload");
+        g_receiverRunning = false;
+    }
+}
+
+bool Transfer::receiverRunning(void)
+{
+    return g_receiverRunning;
+}
+
+std::string Transfer::receiverToken(void)
+{
+    return g_token;
+}
+
+std::string Transfer::receiverIp(void)
+{
+    return g_receiverIp;
+}
+
+int Transfer::receiverPort(void)
+{
+    return g_receiverPort;
+}
+
+std::string Transfer::receiverNotice(void)
+{
+    return g_receiverNotice;
+}
+
+void Transfer::clearReceiverNotice(void)
+{
+    g_receiverNotice.clear();
+}
+
+bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, const std::string& backupName, const std::string& dataType,
+    const std::string& ip, u16 port, const std::string& token, std::string& outError)
+{
+    std::vector<FileEntry> files;
+    u32 zipSize = 0;
+    std::u16string zipPath = StringUtils::UTF8toUTF16(TEMP_ZIP_SEND);
+
+    if (!writeZip(backupPath, zipPath, files, zipSize)) {
+        outError = "Failed to create ZIP.";
+        return false;
+    }
+
+    g_transferBytesTotal = zipSize;
+    g_transferBytesDone = 0;
+    g_transferMode = "Enviando";
+    g_transferIsNetwork = true;
+    g_isTransferringFile = true;
+
+    nlohmann::json meta;
+    meta["titleId"] = StringUtils::format("%016llX", title.id());
+    meta["titleName"] = title.shortDescription();
+    meta["dataType"] = dataType;
+    meta["backupName"] = backupName;
+    meta["zipBytesTotal"] = zipSize;
+    meta["timestamp"] = DateTime::logDateTime();
+
+    std::string metaStr = meta.dump();
+    std::string boundary = "----checkpoint-boundary";
+
+    std::string partMeta = "--" + boundary + "\r\n"
+        "Content-Disposition: form-data; name=\"meta\"\r\n"
+        "Content-Type: application/json\r\n\r\n" +
+        metaStr + "\r\n";
+
+    std::string partFileHeader = "--" + boundary + "\r\n"
+        "Content-Disposition: form-data; name=\"file\"; filename=\"backup.zip\"\r\n"
+        "Content-Type: application/zip\r\n\r\n";
+
+    std::string partEnd = "\r\n--" + boundary + "--\r\n";
+
+    u32 contentLength = partMeta.size() + partFileHeader.size() + zipSize + partEnd.size();
+
+    int sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    if (sock < 0) {
+        g_isTransferringFile = false;
+        g_transferIsNetwork = false;
+        outError = "Failed to open socket.";
+        return false;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr(ip.c_str());
+    if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        close(sock);
+        g_isTransferringFile = false;
+        g_transferIsNetwork = false;
+        outError = "Failed to connect.";
+        return false;
+    }
+
+    std::string header = StringUtils::format("POST /transfer/upload HTTP/1.1\r\nHost: %s:%d\r\nConnection: close\r\n", ip.c_str(), port);
+    header += StringUtils::format("X-CP-Token: %s\r\n", token.c_str());
+    header += StringUtils::format("Content-Type: multipart/form-data; boundary=%s\r\n", boundary.c_str());
+    header += StringUtils::format("Content-Length: %u\r\n\r\n", contentLength);
+
+    bool ok = sendAll(sock, header.data(), header.size()) && sendAll(sock, partMeta.data(), partMeta.size()) && sendAll(sock, partFileHeader.data(),
+        partFileHeader.size());
+
+    if (ok) {
+        FSStream input(Archive::sdmc(), zipPath, FS_OPEN_READ);
+        if (!input.good()) {
+            ok = false;
+        }
+        else {
+            static const u32 kBuf = 0x4000;
+            std::unique_ptr<u8[]> buf(new u8[kBuf]);
+            while (!input.eof()) {
+                u32 rd = input.read(buf.get(), kBuf);
+                if (rd == 0) {
+                    break;
+                }
+                if (!sendAll(sock, buf.get(), rd)) {
+                    ok = false;
+                    break;
+                }
+                g_transferBytesDone += rd;
+
+                C3D_FrameBegin(C3D_FRAME_SYNCDRAW);
+                g_screen->drawTop();
+                C2D_SceneBegin(g_bottom);
+                g_screen->drawBottom();
+                Gui::frameEnd();
+            }
+            input.close();
+        }
+    }
+
+    if (ok) {
+        ok = sendAll(sock, partEnd.data(), partEnd.size());
+    }
+
+    char responseBuf[256];
+    recv(sock, responseBuf, sizeof(responseBuf) - 1, 0);
+
+    close(sock);
+
+    FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, zipPath.data()));
+
+    g_isTransferringFile = false;
+    g_transferIsNetwork = false;
+
+    if (!ok) {
+        outError = "Transfer failed.";
+        return false;
+    }
+
+    return true;
+}

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -129,27 +129,6 @@ namespace {
         return c;
     }
 
-    u32 computeCrc(FS_Archive arch, const std::u16string& path)
-    {
-        FSStream input(arch, path, FS_OPEN_READ);
-        if (!input.good()) {
-            return 0;
-        }
-        initCrc();
-        u32 crc = 0xFFFFFFFFu;
-        static const u32 kBuf = 0x4000;
-        std::unique_ptr<u8[]> buf(new u8[kBuf]);
-        while (!input.eof()) {
-            u32 rd = input.read(buf.get(), kBuf);
-            if (rd == 0) {
-                break;
-            }
-            crc = updateCrc(crc, buf.get(), rd);
-        }
-        input.close();
-        return crc ^ 0xFFFFFFFFu;
-    }
-
     void collectFiles(
         FS_Archive arch, const std::u16string& root, const std::u16string& sub, std::vector<FileEntry>& out, std::vector<std::string>* outDirs = nullptr)
     {
@@ -221,10 +200,6 @@ namespace {
             return false;
         }
 
-        for (auto& entry : files) {
-            entry.crc = computeCrc(Archive::sdmc(), entry.absPath);
-        }
-
         u32 total = 22; // end of central directory
         for (const auto& dir : dirs) {
             total += 30 + dir.size(); // local header
@@ -247,6 +222,7 @@ namespace {
 
         static const u32 kBuf = 0x4000;
         std::unique_ptr<u8[]> buf(new u8[kBuf]);
+        initCrc();
 
         for (const auto& dir : dirs) {
             ZipEntry centralEntry;
@@ -275,10 +251,15 @@ namespace {
         for (const auto& entry : files) {
             ZipEntry centralEntry;
             centralEntry.name = entry.relPath;
-            centralEntry.crc = entry.crc;
+            centralEntry.crc = 0;
             centralEntry.size = entry.size;
             centralEntry.offset = output.offset();
             centralEntry.isDirectory = false;
+
+            // The CRC is computed during the single streaming pass below and
+            // backfilled into this local-header field afterwards, so each file
+            // is read only once instead of once for the CRC and once to stream.
+            u32 crcFieldOffset = centralEntry.offset + 14;
 
             writeLe32(output, 0x04034b50);
             writeLe16(output, 20);
@@ -286,7 +267,7 @@ namespace {
             writeLe16(output, 0);
             writeLe16(output, 0);
             writeLe16(output, 0);
-            writeLe32(output, entry.crc);
+            writeLe32(output, 0); // CRC placeholder, backfilled after streaming
             writeLe32(output, entry.size);
             writeLe32(output, entry.size);
             writeLe16(output, (u16)entry.relPath.size());
@@ -299,17 +280,27 @@ namespace {
                 outError = StringUtils::format("Cannot read source file for packaging (0x%08lX).", input.result());
                 return false;
             }
+            u32 crc = 0xFFFFFFFFu;
             while (!input.eof()) {
                 u32 rd = input.read(buf.get(), kBuf);
                 if (rd == 0) {
                     break;
                 }
+                crc = updateCrc(crc, buf.get(), rd);
                 output.write(buf.get(), rd);
                 transferAddDone(rd);
                 renderTransferFrame();
             }
             input.close();
+            crc ^= 0xFFFFFFFFu;
 
+            // Backfill the real CRC into the local header, then resume appending.
+            u32 endOffset = output.offset();
+            output.offset(crcFieldOffset);
+            writeLe32(output, crc);
+            output.offset(endOffset);
+
+            centralEntry.crc = crc;
             central.push_back(centralEntry);
         }
 
@@ -475,7 +466,6 @@ namespace {
                 input.close();
                 return false;
             }
-            (void)crc;
 
             if (!name.empty() && name.back() == '/') {
                 std::u16string dirPath = destRoot + StringUtils::UTF8toUTF16(name.c_str());
@@ -496,6 +486,8 @@ namespace {
 
             static const u32 kBuf = 0x4000;
             std::unique_ptr<u8[]> buf(new u8[kBuf]);
+            initCrc();
+            u32 computedCrc = 0xFFFFFFFFu;
             u32 remaining = compSize;
             while (remaining > 0) {
                 u32 chunk = remaining > kBuf ? kBuf : remaining;
@@ -506,6 +498,7 @@ namespace {
                     input.close();
                     return false;
                 }
+                computedCrc = updateCrc(computedCrc, buf.get(), rd);
                 output.write(buf.get(), rd);
                 remaining -= rd;
 
@@ -518,6 +511,16 @@ namespace {
                 return false;
             }
             output.close();
+
+            // Verify the extracted data against the CRC stored in the ZIP entry,
+            // so a corrupted or truncated transfer is rejected instead of being
+            // written out as-is.
+            computedCrc ^= 0xFFFFFFFFu;
+            if (computedCrc != crc) {
+                outError = "Checksum mismatch in received file.";
+                input.close();
+                return false;
+            }
         }
 
         input.close();
@@ -630,6 +633,20 @@ namespace {
         return {200, "application/json", info.dump()};
     }
 
+    // Constant-time comparison so a wrong PIN can't be narrowed down by timing
+    // how far the comparison got before it failed.
+    bool constantTimeEquals(const std::string& a, const std::string& b)
+    {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        unsigned char diff = 0;
+        for (size_t i = 0; i < a.size(); ++i) {
+            diff |= (unsigned char)(a[i] ^ b[i]);
+        }
+        return diff == 0;
+    }
+
     Server::HttpResponse handleUpload(const std::string&, const std::string& requestData)
     {
         auto cleanup = []() {
@@ -639,7 +656,7 @@ namespace {
         size_t headerEnd = requestData.find("\r\n\r\n");
         std::string headers = headerEnd == std::string::npos ? requestData : requestData.substr(0, headerEnd);
         std::string token = headerValue(headers, "X-CP-Token");
-        if (token != g_token) {
+        if (!constantTimeEquals(token, g_token)) {
             cleanup();
             return {403, "application/json", "{\"ok\":false,\"error\":\"Invalid token\"}"};
         }
@@ -1002,7 +1019,15 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = inet_addr(ip.c_str());
+    if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {
+        close(sock);
+        if (isZip) {
+            FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, payloadPath.data()));
+        }
+        clearTransferState();
+        outError = "Invalid IP address.";
+        return false;
+    }
     if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
         close(sock);
         if (isZip) {

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -592,10 +592,12 @@ namespace {
 
     Server::HttpResponse handleInfo(const std::string&, const std::string&)
     {
+        // Note: the PIN token is intentionally NOT exposed here. It must only ever
+        // be shown on the receiver's screen and entered manually on the sender, so
+        // that a device on the same network cannot read it and authenticate itself.
         nlohmann::json info;
         info["device"] = "3DS";
         info["version"] = StringUtils::format("%d.%d.%d", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
-        info["token"] = g_token;
         info["maxUploadBytes"] = 0;
         info["freeSpaceBytes"] = 0;
         return {200, "application/json", info.dump()};

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -525,15 +525,24 @@ namespace {
         return headers.substr(pos, end - pos);
     }
 
-    bool parseMultipart(const std::string& request, std::string& outMeta, std::string& outFile, std::string& outError)
+    // Parses the multipart body without copying it. The (small) meta part is
+    // returned by value, but the (potentially large) file part is returned as an
+    // [offset, length) range into the original request buffer so it can be written
+    // straight to disk without duplicating it in memory.
+    bool parseMultipart(const std::string& request, std::string& outMeta, size_t& outFileOffset, size_t& outFileLen, std::string& outError)
     {
+        outMeta.clear();
+        outFileOffset = 0;
+        outFileLen    = 0;
+        bool haveFile = false;
+
         size_t headerEnd = request.find("\r\n\r\n");
         if (headerEnd == std::string::npos) {
             outError = "Bad request.";
             return false;
         }
         std::string headers = request.substr(0, headerEnd);
-        std::string body = request.substr(headerEnd + 4);
+        size_t bodyStart    = headerEnd + 4;
 
         std::string contentType = headerValue(headers, "Content-Type");
         size_t bpos = contentType.find("boundary=");
@@ -547,43 +556,44 @@ namespace {
         }
 
         std::string boundaryMarker = "--" + boundary;
-        size_t pos = body.find(boundaryMarker);
+        std::string nextBoundaryMarker = "\r\n" + boundaryMarker;
+        size_t pos = request.find(boundaryMarker, bodyStart);
         while (pos != std::string::npos) {
             pos += boundaryMarker.size();
-            if (pos + 2 <= body.size() && body.compare(pos, 2, "--") == 0) {
+            if (pos + 2 <= request.size() && request.compare(pos, 2, "--") == 0) {
                 break;
             }
-            if (pos + 2 <= body.size() && body.compare(pos, 2, "\r\n") == 0) {
+            if (pos + 2 <= request.size() && request.compare(pos, 2, "\r\n") == 0) {
                 pos += 2;
             }
 
-            size_t partHeaderEnd = body.find("\r\n\r\n", pos);
+            size_t partHeaderEnd = request.find("\r\n\r\n", pos);
             if (partHeaderEnd == std::string::npos) {
                 break;
             }
-            std::string partHeader = body.substr(pos, partHeaderEnd - pos);
+            std::string partHeader = request.substr(pos, partHeaderEnd - pos);
             size_t dataStart = partHeaderEnd + 4;
-            size_t nextBoundary = body.find("\r\n" + boundaryMarker, dataStart);
+            size_t nextBoundary = request.find(nextBoundaryMarker, dataStart);
             if (nextBoundary == std::string::npos) {
                 break;
             }
-            size_t dataEnd = nextBoundary;
-            if (dataEnd >= 2 && body.compare(dataEnd - 2, 2, "\r\n") == 0) {
-                dataEnd -= 2;
-            }
-            std::string partData = body.substr(dataStart, dataEnd - dataStart);
+            // nextBoundary points at the CRLF that precedes the delimiter, so the
+            // part data is exactly [dataStart, nextBoundary).
+            size_t dataLen = nextBoundary - dataStart;
 
             if (partHeader.find("name=\"meta\"") != std::string::npos) {
-                outMeta = partData;
+                outMeta = request.substr(dataStart, dataLen);
             }
             else if (partHeader.find("name=\"file\"") != std::string::npos) {
-                outFile = partData;
+                outFileOffset = dataStart;
+                outFileLen    = dataLen;
+                haveFile      = true;
             }
 
             pos = nextBoundary + 2;
         }
 
-        if (outMeta.empty() || outFile.empty()) {
+        if (outMeta.empty() || !haveFile) {
             outError = "Incomplete form data.";
             return false;
         }
@@ -618,12 +628,14 @@ namespace {
         }
 
         std::string metaJson;
-        std::string fileData;
+        size_t fileOffset = 0;
+        size_t fileLen    = 0;
         std::string error;
-        if (!parseMultipart(requestData, metaJson, fileData, error)) {
+        if (!parseMultipart(requestData, metaJson, fileOffset, fileLen, error)) {
             cleanup();
             return {400, "application/json", "{\"ok\":false,\"error\":\"Bad upload\"}"};
         }
+        const char* fileData = requestData.data() + fileOffset;
 
         auto meta = nlohmann::json::parse(metaJson, nullptr, false);
         if (meta.is_discarded()) {
@@ -711,21 +723,21 @@ namespace {
             outputPath = backupRoot + safeFileName;
         }
 
-        FSStream output(Archive::sdmc(), outputPath, FS_OPEN_WRITE, (u32)fileData.size());
+        FSStream output(Archive::sdmc(), outputPath, FS_OPEN_WRITE, (u32)fileLen);
         if (!output.good()) {
             cleanup();
             std::string message = StringUtils::format("Failed to store file (0x%08lX).", output.result());
             return {500, "application/json", "{\"ok\":false,\"error\":\"" + message + "\"}"};
         }
-        if (!fileData.empty()) {
-            output.write(fileData.data(), (u32)fileData.size());
+        if (fileLen > 0) {
+            output.write(fileData, (u32)fileLen);
         }
         output.close();
 
         if (isZip) {
             g_transferMode = "Extracting package";
             g_transferIsNetwork = true;
-            g_transferBytesTotal = (u32)fileData.size();
+            g_transferBytesTotal = (u32)fileLen;
             g_transferBytesDone = 0;
 
             std::string extractError;

--- a/3ds/source/transfer.cpp
+++ b/3ds/source/transfer.cpp
@@ -43,6 +43,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -58,8 +59,24 @@ namespace {
     bool g_receiverRunning = false;
     std::atomic<bool> g_pendingRefresh{false};
     std::atomic<bool> g_receiverCompleted{false};
+    // g_receiverNotice / g_receiverCompletedName are written by the HTTP server
+    // thread (in handleUpload) and read by the UI thread, so they are guarded by
+    // this mutex. Pass an empty string to clear.
+    std::mutex g_receiverMutex;
     std::string g_receiverNotice;
     std::string g_receiverCompletedName;
+
+    void setReceiverNotice(const std::string& notice)
+    {
+        std::lock_guard<std::mutex> lock(g_receiverMutex);
+        g_receiverNotice = notice;
+    }
+
+    void setReceiverCompletedName(const std::string& name)
+    {
+        std::lock_guard<std::mutex> lock(g_receiverMutex);
+        g_receiverCompletedName = name;
+    }
 
     struct FileEntry {
         std::u16string absPath;
@@ -288,7 +305,7 @@ namespace {
                     break;
                 }
                 output.write(buf.get(), rd);
-                g_transferBytesDone += rd;
+                transferAddDone(rd);
                 renderTransferFrame();
             }
             input.close();
@@ -492,7 +509,7 @@ namespace {
                 output.write(buf.get(), rd);
                 remaining -= rd;
 
-                g_transferBytesDone += rd;
+                transferAddDone(rd);
             }
             if (remaining != 0) {
                 outError = "Corrupted ZIP payload.";
@@ -648,7 +665,7 @@ namespace {
         std::string titleName = meta.value("titleName", "Unknown");
         std::string backupName = meta.value("backupName", "");
         bool isZip = meta.value("isZip", false);
-        g_receiverNotice.clear();
+        setReceiverNotice("");
         if (backupName.empty()) {
             backupName = "Received_" + DateTime::dateTimeStr();
         }
@@ -675,7 +692,7 @@ namespace {
                 destRoot = (dataType == "extdata") ? t.extdataPath() : t.savePath();
                 foundTitle = true;
                 mappedByName = true;
-                g_receiverNotice = "Warning: title ID mismatch. Backup mapped by title name.";
+                setReceiverNotice("Warning: title ID mismatch. Backup mapped by title name.");
                 Logging::warning("Title ID {} not found, mapped by title name '{}'.", titleId, titleName);
             }
         }
@@ -690,7 +707,7 @@ namespace {
             if (!io::directoryExists(Archive::sdmc(), destRoot)) {
                 io::createDirectory(Archive::sdmc(), destRoot);
             }
-            g_receiverNotice = "Warning: unknown title. Stored in:\n" + StringUtils::UTF16toUTF8(destRoot);
+            setReceiverNotice("Warning: unknown title. Stored in:\n" + StringUtils::UTF16toUTF8(destRoot));
             Logging::warning("Received backup for unknown title {} (stored under {}).", titleId, StringUtils::UTF16toUTF8(destRoot));
         }
 
@@ -735,10 +752,9 @@ namespace {
         output.close();
 
         if (isZip) {
-            g_transferMode = "Extracting package";
+            transferSetMode("Extracting package");
             g_transferIsNetwork = true;
-            g_transferBytesTotal = (u32)fileLen;
-            g_transferBytesDone = 0;
+            transferSetProgress(0, (u64)fileLen);
 
             std::string extractError;
             bool extracted = extractZip(outputPath, backupRoot, extractError);
@@ -750,15 +766,15 @@ namespace {
                 return {500, "application/json", "{\"ok\":false,\"error\":\"" + message + "\"}"};
             }
 
-            g_transferBytesDone = g_transferBytesTotal;
+            transferSetDone((u64)fileLen);
         }
 
         cleanup();
 
         if (!mappedByName && foundTitle) {
-            g_receiverNotice.clear();
+            setReceiverNotice("");
         }
-        g_receiverCompletedName = backupName;
+        setReceiverCompletedName(backupName);
         g_receiverCompleted.store(true);
         g_pendingRefresh.store(true);
 
@@ -795,8 +811,8 @@ bool Transfer::startReceiver(std::string& outError)
         int pin = 1000 + (rand() % 9000);
         g_token = StringUtils::format("%04d", pin);
         g_receiverIp = Server::getAddress();
-        g_receiverNotice.clear();
-        g_receiverCompletedName.clear();
+        setReceiverNotice("");
+        setReceiverCompletedName("");
         g_receiverCompleted.store(false);
         size_t pos = g_receiverIp.find("://");
         if (pos != std::string::npos) {
@@ -852,6 +868,7 @@ int Transfer::receiverPort(void)
 
 std::string Transfer::receiverNotice(void)
 {
+    std::lock_guard<std::mutex> lock(g_receiverMutex);
     return g_receiverNotice;
 }
 
@@ -862,17 +879,18 @@ bool Transfer::receiverHasCompleted(void)
 
 std::string Transfer::receiverCompletedName(void)
 {
+    std::lock_guard<std::mutex> lock(g_receiverMutex);
     return g_receiverCompletedName;
 }
 
 void Transfer::clearReceiverNotice(void)
 {
-    g_receiverNotice.clear();
+    setReceiverNotice("");
 }
 
 void Transfer::clearReceiverCompletion(void)
 {
-    g_receiverCompletedName.clear();
+    setReceiverCompletedName("");
     g_receiverCompleted.store(false);
 }
 
@@ -898,11 +916,10 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
     };
 
     if (isZip) {
-        g_transferMode = "Preparing backup package";
+        transferSetMode("Preparing backup package");
         g_transferIsNetwork = true;
         g_isTransferringFile = true;
-        g_transferBytesDone = 0;
-        g_transferBytesTotal = totalFileBytes(files);
+        transferSetProgress(0, totalFileBytes(files));
 
         std::vector<FileEntry> zipEntries;
         u32 zipSize = 0;
@@ -932,9 +949,8 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
         payloadSize = entry.size;
     }
 
-    g_transferBytesTotal = payloadSize;
-    g_transferBytesDone = 0;
-    g_transferMode = "Sending backup";
+    transferSetProgress(0, payloadSize);
+    transferSetMode("Sending backup");
     g_transferIsNetwork = true;
     g_isTransferringFile = true;
 
@@ -1022,7 +1038,7 @@ bool Transfer::sendBackup(const Title& title, const std::u16string& backupPath, 
                     ok = false;
                     break;
                 }
-                g_transferBytesDone += rd;
+                transferAddDone(rd);
                 renderTransferFrame();
             }
             input.close();

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ SUBDIRS = 3ds switch
 VERSION_MAJOR	:=	3
 VERSION_MINOR	:=	12
 VERSION_MICRO	:=	0
-GIT_REV="$(shell git rev-parse --short HEAD)"
+GIT_REV	:=	$(shell git rev-parse --short HEAD 2>/dev/null)
+ifeq ($(strip $(GIT_REV)),)
+GIT_REV	:=	unknown
+endif
 
 all: $(SUBDIRS)
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "common.hpp"
+#include <cstdint>
 
 std::string DateTime::timeStr(void)
 {
@@ -57,8 +58,51 @@ std::string DateTime::logDateTime(void)
 
 std::string StringUtils::UTF16toUTF8(const std::u16string& src)
 {
-    static std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-    std::string dst = convert.to_bytes(src);
+    std::string dst;
+    dst.reserve(src.size());
+
+    for (size_t i = 0; i < src.size(); ++i) {
+        uint32_t codepoint = src[i];
+
+        if (codepoint >= 0xD800 && codepoint <= 0xDBFF) {
+            if (i + 1 < src.size()) {
+                uint32_t low = src[i + 1];
+                if (low >= 0xDC00 && low <= 0xDFFF) {
+                    codepoint = 0x10000 + (((codepoint - 0xD800) << 10) | (low - 0xDC00));
+                    ++i;
+                }
+                else {
+                    codepoint = 0xFFFD;
+                }
+            }
+            else {
+                codepoint = 0xFFFD;
+            }
+        }
+        else if (codepoint >= 0xDC00 && codepoint <= 0xDFFF) {
+            codepoint = 0xFFFD;
+        }
+
+        if (codepoint <= 0x7F) {
+            dst.push_back(static_cast<char>(codepoint));
+        }
+        else if (codepoint <= 0x7FF) {
+            dst.push_back(static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F)));
+            dst.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+        else if (codepoint <= 0xFFFF) {
+            dst.push_back(static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F)));
+            dst.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            dst.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+        else {
+            dst.push_back(static_cast<char>(0xF0 | ((codepoint >> 18) & 0x07)));
+            dst.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+            dst.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            dst.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+    }
+
     return dst;
 }
 

--- a/common/common.hpp
+++ b/common/common.hpp
@@ -29,9 +29,7 @@
 
 #include <algorithm>
 #include <arpa/inet.h>
-#include <codecvt>
 #include <cstdio>
-#include <locale>
 #include <memory>
 #include <netinet/in.h>
 #include <stdarg.h>


### PR DESCRIPTION
This PR adds local Wi-Fi backup transfer between 3DS consoles in Checkpoint.

## What this adds
- New **Transfer** flow in the 3DS UI (`Send` / `Receive`).
- Receiver mode with **IP / port / PIN token** display.
- Sender upload of the selected save/extdata backup over HTTP multipart.
- Receiver endpoints for transfer negotiation and upload handling.
- Support for both:
  - single-file backups (direct send)
  - multi-file backups (ZIP package + extraction)

- Post-transfer completion state, automatic title list refresh.