### PR TITLE
Add support for emulators

### DIFF
--- a/3ds/source/util.cpp
+++ b/3ds/source/util.cpp
@@ -72,11 +72,16 @@ Result servicesInit(void)
 
     Logging::info("Checkpoint loading started...");
 
-    Handle hbldrHandle;
-    if (R_FAILED(res = svcConnectToPort(&hbldrHandle, "hb:ldr"))) {
-        return consoleDisplayError("Rosalina not found on this system.\nAn updated CFW is required to launch Checkpoint.", res);
+    s64 isEmulator = 0;
+    svcGetSystemInfo(&isEmulator, 0x20000, 0);
+    
+    if (!isEmulator) {
+        Handle hbldrHandle;
+        if (R_FAILED(res = svcConnectToPort(&hbldrHandle, "hb:ldr"))) {
+            return consoleDisplayError("Rosalina not found on this system.\nAn updated CFW is required to launch Checkpoint.", res);
+        }
+        svcCloseHandle(hbldrHandle);
     }
-    svcCloseHandle(hbldrHandle);
 
     if (R_FAILED(res = Archive::init())) {
         return consoleDisplayError("Archive::init failed.", res);


### PR DESCRIPTION
Checkpoint checks for the `hb:ldr` service to detect if the latest CFW is installed. Emulators such as Azahar do not implement this service, but are fully capable of running Checkpoint otherwise. This PR adds an extra check that allows emulators to use Checkpoint by checking SystemInfo type 0x20000,0 (0 -> Real console, 1 -> Citra, 2 -> Azahar) before the service check.

I've tested some basic Checkpoint functionality on Azahar and everything seems to work as intended. We've got a lot of request to support Checkpoint, and this change will allow users to use it.