### PR TITLE
Add Chinese language support to SettingsScreen

### DIFF
--- a/3ds/source/SettingsScreen.cpp
+++ b/3ds/source/SettingsScreen.cpp
@@ -88,7 +88,7 @@ namespace {
 
     // Supported language codes, in cycle order. Adding a language only means
     // appending here (plus its romfs i18n.json entries and isSupported()).
-    const std::string LANGUAGES[]   = {"en", "it", "es", "fr", "de", "pt", "nl", "ja"};
+    const std::string LANGUAGES[]   = {"en", "it", "es", "fr", "de", "pt", "nl", "ja", "zh"};
     constexpr size_t LANGUAGE_COUNT = sizeof(LANGUAGES) / sizeof(LANGUAGES[0]);
 
     // Display name for a language code, in its own language (never localized).

--- a/switch/source/SettingsScreen.cpp
+++ b/switch/source/SettingsScreen.cpp
@@ -75,7 +75,7 @@ namespace {
 
     // Supported language codes, in cycle order. Adding a language only means
     // appending here (plus its romfs i18n.json entries and isSupported()).
-    const std::string LANGUAGES[]   = {"en", "it", "es", "fr", "de", "pt", "nl", "ja"};
+    const std::string LANGUAGES[]   = {"en", "it", "es", "fr", "de", "pt", "nl", "ja", "zh"};
     constexpr size_t LANGUAGE_COUNT = sizeof(LANGUAGES) / sizeof(LANGUAGES[0]);
 
     // Display name for a language code, in its own language (never localized).


### PR DESCRIPTION
resolve https://github.com/BernardoGiordano/Checkpoint/issues/566

I'm quite confused as to why the Chinese option is missing in the settings menu, even though i18n.json already has the Chinese translation.